### PR TITLE
Update backend start instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,13 @@ cd finolo
 
 ### Backend
 
+Backend'i çalıştırabilmek için sisteminizde Maven kurulu olmalıdır. Maven
+yüklü değilse [maven.apache.org](https://maven.apache.org/install.html)
+adresindeki adımları izleyebilirsiniz.
+
 ```bash
 cd backend
-./mvnw spring-boot:run
+mvn spring-boot:run
 ```
 
 ### Frontend


### PR DESCRIPTION
## Summary
- update backend run steps in README to use Maven
- mention Maven installation requirement

## Testing
- `./mvnw -q test` *(fails: InvoiceControllerTest and AuthServiceTest)*

------
https://chatgpt.com/codex/tasks/task_e_6846e834da1c832e9fecb08d1f73a8e0