### PR TITLE
Add role-based authorization

### DIFF
--- a/backend/src/main/java/com/finolo/config/SecurityConfig.java
+++ b/backend/src/main/java/com/finolo/config/SecurityConfig.java
@@ -30,6 +30,9 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/h2-console/**", "/api/auth/**").permitAll()
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/api/invoices/**", "/api/customers/**", "/api/dashboard/**", "/api/user/**")
+                            .hasRole("USER")
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/src/main/java/com/finolo/dto/auth/RegisterRequest.java
+++ b/backend/src/main/java/com/finolo/dto/auth/RegisterRequest.java
@@ -16,4 +16,7 @@ public class RegisterRequest {
 
     @NotBlank(message = "İşletme adı boş olamaz")
     private String businessName;
+
+    // optional, defaults to USER if not provided
+    private String role;
 }

--- a/backend/src/main/java/com/finolo/service/auth/AuthService.java
+++ b/backend/src/main/java/com/finolo/service/auth/AuthService.java
@@ -29,7 +29,7 @@ public class AuthService {
                 .email(request.getEmail())
                 .password(passwordEncoder.encode(request.getPassword()))
                 .businessName(request.getBusinessName())
-                .role("USER")
+                .role(request.getRole() != null ? request.getRole() : "USER")
                 .build();
 
         userRepository.save(user);

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,6 +9,7 @@ import Layout from "./components/Layout.jsx";
 import Invoices from "./pages/Invoices.jsx";
 import InvoiceForm from "./pages/InvoiceForm.jsx";
 import InvoiceDetail from "./pages/InvoiceDetail";
+import AdminPanel from "./pages/AdminPanel.jsx";
 
 function App() {
     return (
@@ -27,6 +28,7 @@ function App() {
                     <Route path="/invoices" element={<Invoices />} />
                     <Route path="/invoices/:id" element={<InvoiceDetail />} />
                     <Route path="/invoice/new" element={<InvoiceForm />} />
+                    <Route path="/admin" element={<AdminPanel />} />
                 </Route>
             </Routes>
         </Router>

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -25,7 +25,15 @@ function Navbar() {
             {/* Masaüstü Menü */}
             <div className="hidden md:flex gap-6 items-center">
                 <NavLink to="/dashboard" className={linkClasses}>Dashboard</NavLink>
-                <NavLink to="/customers" className={linkClasses}>Müşteriler</NavLink>
+                {user?.role === "USER" && (
+                    <>
+                        <NavLink to="/customers" className={linkClasses}>Müşteriler</NavLink>
+                        <NavLink to="/invoices" className={linkClasses}>Faturalar</NavLink>
+                    </>
+                )}
+                {user?.role === "ADMIN" && (
+                    <NavLink to="/admin" className={linkClasses}>Admin</NavLink>
+                )}
                 <NavLink to="/profile" className={linkClasses}>Profil</NavLink>
             </div>
 
@@ -69,9 +77,16 @@ function Navbar() {
 
         <nav className="flex flex-col gap-4 text-lg text-gray-700">
           <NavLink to="/dashboard" className={linkClasses}>Dashboard</NavLink>
-          <NavLink to="/customers" className={linkClasses}>Müşteriler</NavLink>
-            <NavLink to="/invoices" className={linkClasses}>Faturalar</NavLink>
-            <NavLink to="/profile" className={linkClasses}>Profil</NavLink>
+          {user?.role === "USER" && (
+            <>
+              <NavLink to="/customers" className={linkClasses}>Müşteriler</NavLink>
+              <NavLink to="/invoices" className={linkClasses}>Faturalar</NavLink>
+            </>
+          )}
+          {user?.role === "ADMIN" && (
+            <NavLink to="/admin" className={linkClasses}>Admin</NavLink>
+          )}
+          <NavLink to="/profile" className={linkClasses}>Profil</NavLink>
         </nav>
 
         <div className="mt-auto pt-6 border-t text-sm text-gray-600">

--- a/frontend/src/pages/AdminPanel.jsx
+++ b/frontend/src/pages/AdminPanel.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+function AdminPanel() {
+    return (
+        <div className="p-4">
+            <h2 className="text-2xl font-bold text-indigo-600">Admin Panel</h2>
+            <p>Yalnızca yöneticiler için erişilebilir.</p>
+        </div>
+    );
+}
+
+export default AdminPanel;


### PR DESCRIPTION
## Summary
- add role field to `RegisterRequest`
- assign role during registration
- restrict API paths by roles
- show admin link only when `user.role === "ADMIN"`
- add a placeholder admin panel

## Testing
- `mvn -q -f backend/pom.xml test` *(fails: No value at JSON path and NullPointer)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6846ebd707a8832ea7d5b187697532cf