### PR TITLE
Add welcome email service

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -39,6 +39,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
         </dependency>

--- a/backend/src/main/java/com/finolo/service/auth/AuthService.java
+++ b/backend/src/main/java/com/finolo/service/auth/AuthService.java
@@ -6,6 +6,7 @@ import com.finolo.dto.auth.RegisterRequest;
 import com.finolo.model.User;
 import com.finolo.repository.UserRepository;
 import com.finolo.security.JwtService;
+import com.finolo.service.mail.MailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -19,6 +20,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtService jwtService;
+    private final MailService mailService;
 
     public AuthResponse register(RegisterRequest request) {
         if (userRepository.existsByEmail(request.getEmail())) {
@@ -33,6 +35,9 @@ public class AuthService {
                 .build();
 
         userRepository.save(user);
+
+        // Yeni kullanıcıya hoş geldiniz e-postası gönder
+        mailService.sendWelcomeMail(user.getEmail());
 
         String token = jwtService.generateToken(user.getUsername());
 

--- a/backend/src/main/java/com/finolo/service/mail/MailService.java
+++ b/backend/src/main/java/com/finolo/service/mail/MailService.java
@@ -1,0 +1,21 @@
+package com.finolo.service.mail;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+    private final JavaMailSender mailSender;
+
+    public void sendWelcomeMail(String to) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setSubject("Finolo'ya Hoş Geldiniz!");
+        message.setText("Finolo'ya kayıt olduğunuz için teşekkür ederiz.");
+        mailSender.send(message);
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -8,3 +8,11 @@ spring.web.resources.add-mappings=false
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.ddl-auto=update
 spring.h2.console.enabled=true
+
+# SMTP configuration
+spring.mail.host=smtp.example.com
+spring.mail.port=587
+spring.mail.username=no-reply@example.com
+spring.mail.password=change-me
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true

--- a/backend/src/test/java/com/finolo/controller/invoice/InvoiceControllerTest.java
+++ b/backend/src/test/java/com/finolo/controller/invoice/InvoiceControllerTest.java
@@ -89,8 +89,8 @@ class InvoiceControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(invoiceRequest)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.invoiceNumber").value("INV-TEST-123456"))
-                .andExpect(jsonPath("$.amount").value(2500.0));
+                .andExpect(jsonPath("$.data.invoiceNumber").value("INV-TEST-123456"))
+                .andExpect(jsonPath("$.data.amount").value(2500.0));
     }
 
     @Test
@@ -100,8 +100,8 @@ class InvoiceControllerTest {
 
         mockMvc.perform(get("/api/invoices"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].invoiceNumber").value("INV-TEST-123456"))
-                .andExpect(jsonPath("$[0].amount").value(2500.0))
-                .andExpect(jsonPath("$[0].status").value("DRAFT"));
+                .andExpect(jsonPath("$.data[0].invoiceNumber").value("INV-TEST-123456"))
+                .andExpect(jsonPath("$.data[0].amount").value(2500.0))
+                .andExpect(jsonPath("$.data[0].status").value("DRAFT"));
     }
 }

--- a/backend/src/test/java/com/finolo/service/auth/AuthServiceTest.java
+++ b/backend/src/test/java/com/finolo/service/auth/AuthServiceTest.java
@@ -3,6 +3,8 @@ package com.finolo.service.auth;
 import com.finolo.dto.auth.RegisterRequest;
 import com.finolo.model.User;
 import com.finolo.repository.UserRepository;
+import com.finolo.service.mail.MailService;
+import com.finolo.security.JwtService;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -25,6 +27,12 @@ class AuthServiceTest {
     @Mock
     private PasswordEncoder passwordEncoder;
 
+    @Mock
+    private MailService mailService;
+
+    @Mock
+    private JwtService jwtService;
+
     @InjectMocks
     private AuthService authService;
 
@@ -44,12 +52,14 @@ class AuthServiceTest {
 
         when(userRepository.existsByEmail("test@example.com")).thenReturn(false);
         when(passwordEncoder.encode("password123")).thenReturn("hashed-pass");
+        when(jwtService.generateToken(any())).thenReturn("jwt-token");
 
         var response = authService.register(request);
 
         assertThat(response.getEmail()).isEqualTo("test@example.com");
         assertThat(response.getRole()).isEqualTo("USER");
         verify(userRepository, times(1)).save(any(User.class));
+        verify(mailService, times(1)).sendWelcomeMail("test@example.com");
     }
 
     @Test
@@ -66,5 +76,7 @@ class AuthServiceTest {
         assertThat(exception.getMessage()).isEqualTo("Bu e-posta zaten kayıtlı.");
 
         verify(userRepository, never()).save(any());
+        verify(mailService, never()).sendWelcomeMail(any());
+        verify(jwtService, never()).generateToken(any());
     }
 }


### PR DESCRIPTION
## Summary
- add spring-boot-starter-mail dependency
- create MailService for sending welcome emails
- trigger welcome email in AuthService.register
- add SMTP placeholders in application.properties
- update tests for invoice controller and auth service

## Testing
- `./mvnw -q test`

------
https://chatgpt.com/codex/tasks/task_e_6846ebdb0de4832ea32f770d75d4be66