### PR TITLE
Add invoice export endpoints and frontend buttons

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -96,6 +96,18 @@
             <scope>test</scope>
         </dependency>
 
+        <!-- Export dependencies -->
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-ooxml</artifactId>
+            <version>5.2.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.itextpdf</groupId>
+            <artifactId>itextpdf</artifactId>
+            <version>5.5.13.2</version>
+        </dependency>
+
 
 
     </dependencies>

--- a/backend/src/main/java/com/finolo/controller/invoice/InvoiceController.java
+++ b/backend/src/main/java/com/finolo/controller/invoice/InvoiceController.java
@@ -6,6 +6,9 @@ import com.finolo.dto.invoice.InvoiceResponse;
 import com.finolo.service.invoice.InvoiceService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -45,6 +48,26 @@ public class InvoiceController {
     public ResponseEntity<BaseResponse<InvoiceResponse>> updateInvoice(@PathVariable Long id, @RequestBody @Valid InvoiceRequest request) {
         InvoiceResponse updated = invoiceService.updateInvoice(id, request);
         return ResponseEntity.ok(BaseResponse.success(updated, "Fatura güncellendi"));
+    }
+
+    @GetMapping("/export/pdf")
+    public ResponseEntity<byte[]> exportPdf() {
+        byte[] data = invoiceService.exportInvoicesToPdf();
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        ContentDisposition.attachment().filename("invoices.pdf").build().toString())
+                .contentType(MediaType.APPLICATION_PDF)
+                .body(data);
+    }
+
+    @GetMapping("/export/excel")
+    public ResponseEntity<byte[]> exportExcel() {
+        byte[] data = invoiceService.exportInvoicesToExcel();
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        ContentDisposition.attachment().filename("invoices.xlsx").build().toString())
+                .contentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
+                .body(data);
     }
 
 }

--- a/backend/src/main/java/com/finolo/service/invoice/InvoiceService.java
+++ b/backend/src/main/java/com/finolo/service/invoice/InvoiceService.java
@@ -9,12 +9,22 @@ import com.finolo.model.User;
 import com.finolo.repository.CustomerRepository;
 import com.finolo.repository.InvoiceRepository;
 import lombok.RequiredArgsConstructor;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import com.itextpdf.text.Document;
+import com.itextpdf.text.DocumentException;
+import com.itextpdf.text.pdf.PdfPTable;
+import com.itextpdf.text.pdf.PdfWriter;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import java.nio.file.AccessDeniedException;
 import java.time.LocalDate;
 import java.util.List;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 
 @Service
 @RequiredArgsConstructor
@@ -141,6 +151,62 @@ public class InvoiceService {
 
         Invoice updated = invoiceRepository.save(invoice);
         return invoiceMapper.toResponse(updated);
+    }
+
+    public byte[] exportInvoicesToPdf() {
+        User currentUser = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        List<Invoice> invoices = invoiceRepository.findByUser(currentUser);
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            Document document = new Document();
+            PdfWriter.getInstance(document, out);
+            document.open();
+            PdfPTable table = new PdfPTable(5);
+            table.addCell("Invoice No");
+            table.addCell("Customer");
+            table.addCell("Date");
+            table.addCell("Amount");
+            table.addCell("Status");
+            for (Invoice invoice : invoices) {
+                table.addCell(invoice.getInvoiceNumber());
+                table.addCell(invoice.getCustomer().getName());
+                table.addCell(invoice.getDate().toString());
+                table.addCell(String.valueOf(invoice.getAmount()));
+                table.addCell(invoice.getStatus());
+            }
+            document.add(table);
+            document.close();
+            return out.toByteArray();
+        } catch (DocumentException | IOException e) {
+            throw new RuntimeException("PDF oluşturulamadı", e);
+        }
+    }
+
+    public byte[] exportInvoicesToExcel() {
+        User currentUser = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        List<Invoice> invoices = invoiceRepository.findByUser(currentUser);
+        try (Workbook workbook = new XSSFWorkbook(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            Sheet sheet = workbook.createSheet("Invoices");
+            Row header = sheet.createRow(0);
+            header.createCell(0).setCellValue("Invoice No");
+            header.createCell(1).setCellValue("Customer");
+            header.createCell(2).setCellValue("Date");
+            header.createCell(3).setCellValue("Amount");
+            header.createCell(4).setCellValue("Status");
+
+            int rowIdx = 1;
+            for (Invoice inv : invoices) {
+                Row row = sheet.createRow(rowIdx++);
+                row.createCell(0).setCellValue(inv.getInvoiceNumber());
+                row.createCell(1).setCellValue(inv.getCustomer().getName());
+                row.createCell(2).setCellValue(inv.getDate().toString());
+                row.createCell(3).setCellValue(inv.getAmount());
+                row.createCell(4).setCellValue(inv.getStatus());
+            }
+            workbook.write(out);
+            return out.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException("Excel oluşturulamadı", e);
+        }
     }
 
 }

--- a/backend/src/test/java/com/finolo/controller/invoice/InvoiceControllerTest.java
+++ b/backend/src/test/java/com/finolo/controller/invoice/InvoiceControllerTest.java
@@ -89,8 +89,8 @@ class InvoiceControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(invoiceRequest)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.invoiceNumber").value("INV-TEST-123456"))
-                .andExpect(jsonPath("$.amount").value(2500.0));
+                .andExpect(jsonPath("$.data.invoiceNumber").value("INV-TEST-123456"))
+                .andExpect(jsonPath("$.data.amount").value(2500.0));
     }
 
     @Test
@@ -100,8 +100,8 @@ class InvoiceControllerTest {
 
         mockMvc.perform(get("/api/invoices"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].invoiceNumber").value("INV-TEST-123456"))
-                .andExpect(jsonPath("$[0].amount").value(2500.0))
-                .andExpect(jsonPath("$[0].status").value("DRAFT"));
+                .andExpect(jsonPath("$.data[0].invoiceNumber").value("INV-TEST-123456"))
+                .andExpect(jsonPath("$.data[0].amount").value(2500.0))
+                .andExpect(jsonPath("$.data[0].status").value("DRAFT"));
     }
 }

--- a/backend/src/test/java/com/finolo/service/auth/AuthServiceTest.java
+++ b/backend/src/test/java/com/finolo/service/auth/AuthServiceTest.java
@@ -3,6 +3,7 @@ package com.finolo.service.auth;
 import com.finolo.dto.auth.RegisterRequest;
 import com.finolo.model.User;
 import com.finolo.repository.UserRepository;
+import com.finolo.security.JwtService;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -25,6 +26,9 @@ class AuthServiceTest {
     @Mock
     private PasswordEncoder passwordEncoder;
 
+    @Mock
+    private JwtService jwtService;
+
     @InjectMocks
     private AuthService authService;
 
@@ -44,6 +48,7 @@ class AuthServiceTest {
 
         when(userRepository.existsByEmail("test@example.com")).thenReturn(false);
         when(passwordEncoder.encode("password123")).thenReturn("hashed-pass");
+        when(jwtService.generateToken(anyString())).thenReturn("token");
 
         var response = authService.register(request);
 

--- a/frontend/src/pages/Invoices.jsx
+++ b/frontend/src/pages/Invoices.jsx
@@ -1,5 +1,5 @@
 import {useEffect, useState} from "react";
-import {deleteInvoice, getInvoices} from "../services/invoiceService";
+import {deleteInvoice, getInvoices, exportInvoicesPdf, exportInvoicesExcel} from "../services/invoiceService";
 import {Link} from "react-router-dom";
 import {formatDate} from "../utils/dateUtils";
 import {Plus} from "lucide-react";
@@ -35,9 +35,51 @@ function Invoices() {
         }
     };
 
+    const downloadFile = (data, filename) => {
+        const url = window.URL.createObjectURL(new Blob([data]));
+        const link = document.createElement("a");
+        link.href = url;
+        link.setAttribute("download", filename);
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+    };
+
+    const handleExportPdf = async () => {
+        try {
+            const res = await exportInvoicesPdf();
+            downloadFile(res.data, "invoices.pdf");
+        } catch (err) {
+            console.error("PDF indirilemedi", err);
+        }
+    };
+
+    const handleExportExcel = async () => {
+        try {
+            const res = await exportInvoicesExcel();
+            downloadFile(res.data, "invoices.xlsx");
+        } catch (err) {
+            console.error("Excel indirilemedi", err);
+        }
+    };
+
     return (
         <div className="overflow-x-auto w-full">
             <h2 className="text-2xl font-bold text-indigo-600 mb-4">Faturalar</h2>
+            <div className="flex justify-end space-x-2 mb-4">
+                <button
+                    onClick={handleExportPdf}
+                    className="px-3 py-2 text-sm rounded bg-indigo-600 text-white hover:bg-indigo-700"
+                >
+                    PDF İndir
+                </button>
+                <button
+                    onClick={handleExportExcel}
+                    className="px-3 py-2 text-sm rounded bg-green-600 text-white hover:bg-green-700"
+                >
+                    Excel İndir
+                </button>
+            </div>
 
             <table className="min-w-full w-full text-sm text-left text-gray-700 bg-white shadow rounded">
                 <thead className="bg-gray-100 text-sm text-gray-700">

--- a/frontend/src/services/invoiceService.js
+++ b/frontend/src/services/invoiceService.js
@@ -25,4 +25,12 @@ export const updateInvoice = async (id, data) => {
     return res.data;
 };
 
+export const exportInvoicesPdf = async () => {
+    return api.get('/invoices/export/pdf', { responseType: 'blob' });
+};
+
+export const exportInvoicesExcel = async () => {
+    return api.get('/invoices/export/excel', { responseType: 'blob' });
+};
+
 


### PR DESCRIPTION
## Summary
- add Apache POI and iText dependencies
- implement PDF and Excel export methods in `InvoiceService`
- expose `/export/pdf` and `/export/excel` routes on `InvoiceController`
- update tests for new response structure and inject JwtService mock
- add download buttons to invoices page
- support export helpers in invoice service on frontend

## Testing
- `./mvnw -q test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6846f0eb1c30832e8d152fe6c8870cf6