### PR TITLE
Add first login tutorial overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Finolo, küçük ve orta ölçekli işletmeler için geliştirilen modern, hızl
 - [x] Müşteri ve fatura yönetimi ekranları
 - [x] Reusable bileşen yapısı (Cards, Charts, Modals)
 - [x] Mobil uyumlu tasarım
+- [x] İlk girişte açılan kısa yardım rehberi
 
 ---
 
@@ -67,6 +68,10 @@ cd frontend
 npm install
 npm run dev
 ```
+
+### Yardım Rehberi
+
+Uygulamaya ilk kez girdiğinizde kısa bir rehber görünür. Rehber kapatıldığında tarayıcınızda `tutorialShown` anahtarı kaydedilir. Tekrar görmek isterseniz bu anahtarı silmeniz yeterlidir.
 
 ---
 

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,9 +1,25 @@
 import Navbar from "./Navbar";
 import {Outlet} from "react-router-dom";
+import {useEffect, useState} from "react";
+import TutorialOverlay from "./TutorialOverlay";
 
 function Layout() {
+    const [showTutorial, setShowTutorial] = useState(false);
+
+    useEffect(() => {
+        if (!localStorage.getItem("tutorialShown")) {
+            setShowTutorial(true);
+        }
+    }, []);
+
+    const closeTutorial = () => {
+        localStorage.setItem("tutorialShown", "true");
+        setShowTutorial(false);
+    };
+
     return (
         <div className="flex flex-col min-h-screen bg-gray-100">
+            {showTutorial && <TutorialOverlay onClose={closeTutorial} />}
             <Navbar />
             <main className="flex-1 px-4 py-6 max-w-7xl mx-auto w-full">
                 <Outlet />

--- a/frontend/src/components/TutorialOverlay.jsx
+++ b/frontend/src/components/TutorialOverlay.jsx
@@ -1,0 +1,35 @@
+import {useState} from "react";
+
+function TutorialOverlay({ onClose }) {
+    const steps = [
+        { title: "Hoş Geldiniz", text: "Dashboard'da özet finans verilerini inceleyebilirsiniz." },
+        { title: "Müşteriler", text: "Müşteri kayıtlarınızı ve bilgilerini yönetin." },
+        { title: "Faturalar", text: "Yeni faturalar oluşturup geçmiş işlemleri takip edin." }
+    ];
+    const [index, setIndex] = useState(0);
+
+    const next = () => {
+        if (index < steps.length - 1) {
+            setIndex(index + 1);
+        } else {
+            onClose();
+        }
+    };
+
+    return (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+            <div className="bg-white p-6 rounded shadow max-w-md w-full text-center">
+                <h2 className="text-xl font-bold mb-2">{steps[index].title}</h2>
+                <p className="mb-4">{steps[index].text}</p>
+                <button
+                    onClick={next}
+                    className="bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700"
+                >
+                    {index < steps.length - 1 ? "Devam" : "Kapat"}
+                </button>
+            </div>
+        </div>
+    );
+}
+
+export default TutorialOverlay;


### PR DESCRIPTION
## Summary
- add `TutorialOverlay` component with simple multi-step guide
- show overlay in `Layout` only if localStorage doesn't contain `tutorialShown`
- document the new help overlay in the README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6846ebe24bf8832e91938e9dc3d2ad03