### PR TITLE
Add dashboard operations list

### DIFF
--- a/backend/src/main/java/com/finolo/controller/dashboard/DashboardController.java
+++ b/backend/src/main/java/com/finolo/controller/dashboard/DashboardController.java
@@ -2,6 +2,7 @@ package com.finolo.controller.dashboard;
 
 import com.finolo.dto.common.BaseResponse;
 import com.finolo.dto.dashboard.DashboardSummaryResponse;
+import com.finolo.dto.dashboard.OperationResponse;
 import com.finolo.dto.invoice.InvoiceResponse;
 import com.finolo.service.dashboard.DashboardService;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +43,12 @@ public class DashboardController {
     public ResponseEntity<BaseResponse<Map<String, Long>>> getPaymentStats() {
         var stats = dashboardService.getPaymentStats();
         return ResponseEntity.ok(BaseResponse.success(stats, "Tahsilat durumu getirildi"));
+    }
+
+    @GetMapping("/operations")
+    public ResponseEntity<BaseResponse<List<OperationResponse>>> getOperations() {
+        var ops = dashboardService.getRecentOperations();
+        return ResponseEntity.ok(BaseResponse.success(ops, "Son işlemler getirildi"));
     }
 
 

--- a/backend/src/main/java/com/finolo/dto/dashboard/OperationResponse.java
+++ b/backend/src/main/java/com/finolo/dto/dashboard/OperationResponse.java
@@ -1,0 +1,18 @@
+package com.finolo.dto.dashboard;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OperationResponse {
+    private String type;
+    private String message;
+    private LocalDate date;
+}

--- a/backend/src/main/java/com/finolo/repository/CustomerRepository.java
+++ b/backend/src/main/java/com/finolo/repository/CustomerRepository.java
@@ -10,4 +10,5 @@ public interface CustomerRepository extends JpaRepository<Customer, Long> {
     List<Customer> findByUser(User user);
     List<Customer> findAllByUser_Email(String email);
     int countByUser(User user);
+    List<Customer> findTop5ByUserOrderByIdDesc(User user);
 }

--- a/backend/src/main/java/com/finolo/repository/InvoiceRepository.java
+++ b/backend/src/main/java/com/finolo/repository/InvoiceRepository.java
@@ -17,6 +17,7 @@ public interface InvoiceRepository extends JpaRepository<Invoice, Long> {
     @Query("SELECT SUM(i.amount) FROM Invoice i WHERE i.user = :user")
     Optional<Double> sumAmountByUser(@Param("user") User user);
     List<Invoice> findTop5ByUserOrderByDateDesc(User user);
+    List<Invoice> findTop5ByUserOrderByCreatedAtDesc(User user);
     List<Invoice> findByUserAndDateAfter(User user, LocalDate date);
 
 

--- a/backend/src/test/java/com/finolo/service/dashboard/DashboardServiceTest.java
+++ b/backend/src/test/java/com/finolo/service/dashboard/DashboardServiceTest.java
@@ -1,0 +1,63 @@
+package com.finolo.service.dashboard;
+
+import com.finolo.dto.dashboard.OperationResponse;
+import com.finolo.mapper.InvoiceMapper;
+import com.finolo.model.Customer;
+import com.finolo.model.Invoice;
+import com.finolo.model.User;
+import com.finolo.repository.CustomerRepository;
+import com.finolo.repository.InvoiceRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+class DashboardServiceTest {
+
+    @Mock
+    private InvoiceRepository invoiceRepository;
+    @Mock
+    private CustomerRepository customerRepository;
+
+    @InjectMocks
+    private DashboardService dashboardService;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        dashboardService = new DashboardService(invoiceRepository, customerRepository, new InvoiceMapper());
+        user = User.builder().id(1L).email("test@finolo.com").build();
+        SecurityContext context = org.mockito.Mockito.mock(SecurityContext.class);
+        when(context.getAuthentication()).thenReturn(new UsernamePasswordAuthenticationToken(user, null));
+        SecurityContextHolder.setContext(context);
+    }
+
+    @Test
+    void testGetRecentOperations() {
+        Invoice inv = Invoice.builder()
+                .id(1L)
+                .createdAt(LocalDate.now())
+                .invoiceNumber("INV-1")
+                .customer(Customer.builder().name("Ali").build())
+                .build();
+
+        when(invoiceRepository.findTop5ByUserOrderByCreatedAtDesc(user)).thenReturn(List.of(inv));
+        when(customerRepository.findTop5ByUserOrderByIdDesc(user)).thenReturn(List.of(Customer.builder().name("Veli").build()));
+
+        List<OperationResponse> ops = dashboardService.getRecentOperations();
+        assertEquals(2, ops.size());
+        assertEquals("INVOICE", ops.get(0).getType());
+    }
+}

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from "react";
-import {getDashboardSummary, getMonthlyStats, getPaymentStats, getRecentInvoices} from "../services/dashboardService";
+import {getDashboardSummary, getMonthlyStats, getPaymentStats, getRecentInvoices, getRecentOperations} from "../services/dashboardService";
 import DashboardCard from "../components/DashboardCard";
 import MonthlyBarChart from "../components/MonthlyBarChart";
 import PaymentDonutChart from "../components/PaymentDonutChart";
@@ -10,6 +10,7 @@ function Dashboard() {
     const [recentInvoices, setRecentInvoices] = useState([]);
     const [monthlyStats, setMonthlyStats] = useState([]);
     const [paymentStats, setPaymentStats] = useState({});
+    const [operations, setOperations] = useState([]);
     const [error, setError] = useState("");
 
     useEffect(() => {
@@ -29,6 +30,9 @@ function Dashboard() {
                     }));
                     setMonthlyStats(chartData);
                 }
+
+                const opsData = await getRecentOperations();
+                if (opsData.success) setOperations(opsData.data);
 
                 const fetchPayments = await getPaymentStats();
                 if (fetchPayments.success) setPaymentStats(fetchPayments.data);
@@ -82,6 +86,20 @@ function Dashboard() {
                     </table>
                 ) : (
                     <p className="text-gray-500">Kayıtlı fatura bulunamadı.</p>
+                )}
+            </div>
+
+            {/* Son İşlemler */}
+            <div className="bg-white p-4 rounded shadow">
+                <h2 className="text-lg font-semibold text-indigo-600 mb-4">Son İşlemler</h2>
+                {operations.length > 0 ? (
+                    <ul className="list-disc pl-5 space-y-1 text-sm">
+                        {operations.map((op, idx) => (
+                            <li key={idx}>{op.message}</li>
+                        ))}
+                    </ul>
+                ) : (
+                    <p className="text-gray-500">Kayıtlı işlem bulunamadı.</p>
                 )}
             </div>
 

--- a/frontend/src/services/dashboardService.js
+++ b/frontend/src/services/dashboardService.js
@@ -19,3 +19,8 @@ export const getPaymentStats = async () => {
     const res = await api.get("/dashboard/payment-stats");
     return res.data;
 };
+
+export const getRecentOperations = async () => {
+    const res = await api.get("/dashboard/operations");
+    return res.data;
+};


### PR DESCRIPTION
## Summary
- show recent operations on dashboard
- expose new `/api/dashboard/operations` route
- support retrieving recent customer/invoice operations in the backend
- add unit test for dashboard service

## Testing
- `npm run lint` *(fails: 'err' is defined but never used)*
- `./mvnw -q test` *(fails: InvoiceControllerTest and AuthServiceTest)*

------
https://chatgpt.com/codex/tasks/task_e_6846ebe18f60832eac7192613c0cbf6d