### PR TITLE
Add customer detail page, make invoices fully editable

### DIFF
--- a/backend/src/main/java/com/finolo/service/invoice/InvoiceService.java
+++ b/backend/src/main/java/com/finolo/service/invoice/InvoiceService.java
@@ -137,6 +137,14 @@ public class InvoiceService {
         invoice.setAmount(request.getAmount());
         invoice.setDescription(request.getDescription());
         invoice.setStatus(request.getStatus());
+        invoice.setDueDate(request.getDueDate());
+        invoice.setTaxRate(request.getTaxRate());
+        invoice.setPaymentMethod(request.getPaymentMethod());
+        invoice.setNote(request.getNote());
+
+        double taxRate = request.getTaxRate() != null ? request.getTaxRate() : 0.0;
+        invoice.setTotalWithTax(request.getAmount() * (1 + (taxRate / 100.0)));
+
         invoice.setCustomer(customer);
 
         Invoice updated = invoiceRepository.save(invoice);

--- a/backend/src/test/java/com/finolo/controller/invoice/InvoiceControllerTest.java
+++ b/backend/src/test/java/com/finolo/controller/invoice/InvoiceControllerTest.java
@@ -89,8 +89,8 @@ class InvoiceControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(invoiceRequest)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.invoiceNumber").value("INV-TEST-123456"))
-                .andExpect(jsonPath("$.amount").value(2500.0));
+                .andExpect(jsonPath("$.data.invoiceNumber").value("INV-TEST-123456"))
+                .andExpect(jsonPath("$.data.amount").value(2500.0));
     }
 
     @Test
@@ -100,8 +100,8 @@ class InvoiceControllerTest {
 
         mockMvc.perform(get("/api/invoices"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].invoiceNumber").value("INV-TEST-123456"))
-                .andExpect(jsonPath("$[0].amount").value(2500.0))
-                .andExpect(jsonPath("$[0].status").value("DRAFT"));
+                .andExpect(jsonPath("$.data[0].invoiceNumber").value("INV-TEST-123456"))
+                .andExpect(jsonPath("$.data[0].amount").value(2500.0))
+                .andExpect(jsonPath("$.data[0].status").value("DRAFT"));
     }
 }

--- a/backend/src/test/java/com/finolo/service/auth/AuthServiceTest.java
+++ b/backend/src/test/java/com/finolo/service/auth/AuthServiceTest.java
@@ -3,6 +3,7 @@ package com.finolo.service.auth;
 import com.finolo.dto.auth.RegisterRequest;
 import com.finolo.model.User;
 import com.finolo.repository.UserRepository;
+import com.finolo.security.JwtService;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -25,6 +26,9 @@ class AuthServiceTest {
     @Mock
     private PasswordEncoder passwordEncoder;
 
+    @Mock
+    private JwtService jwtService;
+
     @InjectMocks
     private AuthService authService;
 
@@ -44,6 +48,7 @@ class AuthServiceTest {
 
         when(userRepository.existsByEmail("test@example.com")).thenReturn(false);
         when(passwordEncoder.encode("password123")).thenReturn("hashed-pass");
+        when(jwtService.generateToken(any())).thenReturn("mock-token");
 
         var response = authService.register(request);
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import Login from "./pages/Login";
 import Register from "./pages/Register";
 import Dashboard from "./pages/Dashboard";
 import Customers from "./pages/Customers";
+import CustomerDetail from "./pages/CustomerDetail";
 import Profile from "./pages/Profile";
 import PrivateRoute from "./routes/PrivateRoute";
 import Layout from "./components/Layout.jsx";
@@ -23,6 +24,7 @@ function App() {
                     <Route path="/dashboard" element={<Dashboard />} />
                     <Route path="/customers" element={<Customers />} />
                     <Route path="/customers/new" element={<Customers />} />
+                    <Route path="/customers/:id" element={<CustomerDetail />} />
                     <Route path="/profile" element={<Profile />} />
                     <Route path="/invoices" element={<Invoices />} />
                     <Route path="/invoices/:id" element={<InvoiceDetail />} />

--- a/frontend/src/pages/CustomerDetail.jsx
+++ b/frontend/src/pages/CustomerDetail.jsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { getCustomers } from "../services/customerService";
+import { getInvoices } from "../services/invoiceService";
+import { formatDate } from "../utils/dateUtils";
+import { ArrowLeft } from "lucide-react";
+
+function CustomerDetail() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+
+  const [customer, setCustomer] = useState(null);
+  const [invoices, setInvoices] = useState([]);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const customerList = await getCustomers();
+        const found = customerList.find((c) => String(c.id) === String(id));
+        setCustomer(found);
+
+        const invRes = await getInvoices();
+        if (invRes.success) {
+          const related = invRes.data.filter((inv) => inv.customerId === Number(id));
+          setInvoices(related);
+        }
+      } catch (err) {
+        setError("Veriler alınamadı.");
+      }
+    };
+
+    fetchData();
+  }, [id]);
+
+  if (!customer) return <p className="text-center text-gray-500">Yükleniyor...</p>;
+
+  return (
+    <div className="max-w-2xl mx-auto bg-white p-6 rounded shadow mt-6">
+      <button
+        onClick={() => navigate("/customers")}
+        className="mb-4 text-sm text-gray-600 hover:text-indigo-600 flex items-center"
+      >
+        <ArrowLeft className="w-4 h-4 mr-1" />
+        Müşterilere Dön
+      </button>
+
+      <h2 className="text-xl font-bold text-indigo-600 mb-4">Müşteri Detayı</h2>
+
+      <div className="space-y-1 text-sm mb-6">
+        <p>
+          <strong>Ad:</strong> {customer.name}
+        </p>
+        <p>
+          <strong>Email:</strong> {customer.email}
+        </p>
+        <p>
+          <strong>Telefon:</strong> {customer.phone}
+        </p>
+        <p>
+          <strong>Adres:</strong> {customer.address}
+        </p>
+      </div>
+
+      <h3 className="text-lg font-semibold text-indigo-600 mb-2">Faturalar</h3>
+      {invoices.length > 0 ? (
+        <table className="w-full text-sm">
+          <thead className="bg-gray-100 text-left">
+            <tr>
+              <th className="px-4 py-2">Fatura No</th>
+              <th className="px-4 py-2">Tarih</th>
+              <th className="px-4 py-2">Tutar</th>
+              <th className="px-4 py-2">Durum</th>
+            </tr>
+          </thead>
+          <tbody>
+            {invoices.map((inv) => (
+              <tr key={inv.id} className="border-b">
+                <td className="px-4 py-2">{inv.invoiceNumber}</td>
+                <td className="px-4 py-2">{formatDate(inv.date)}</td>
+                <td className="px-4 py-2">{inv.amount} ₺</td>
+                <td className="px-4 py-2">
+                  {inv.status === "PAID" ? "Ödenmiş" : "Ödenmemiş"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p className="text-sm text-gray-500">Bu müşteriye ait fatura bulunmuyor.</p>
+      )}
+
+      {error && <p className="text-red-500 text-sm mt-4">{error}</p>}
+    </div>
+  );
+}
+
+export default CustomerDetail;

--- a/frontend/src/pages/Customers.jsx
+++ b/frontend/src/pages/Customers.jsx
@@ -23,7 +23,11 @@ function Customers() {
       <h2 className="text-2xl font-bold mb-4">Müşteriler</h2>
       <div className="grid grid-cols-1 gap-4">
         {customers.map((c) => (
-          <div key={c.id} className="p-4 bg-white rounded shadow">
+          <div
+            key={c.id}
+            onClick={() => navigate(`/customers/${c.id}`)}
+            className="p-4 bg-white rounded shadow cursor-pointer hover:bg-gray-50"
+          >
             <h3 className="text-lg font-semibold">{c.name}</h3>
             <p>{c.email}</p>
             <p>{c.phone}</p>

--- a/frontend/src/pages/InvoiceDetail.jsx
+++ b/frontend/src/pages/InvoiceDetail.jsx
@@ -110,6 +110,41 @@ function InvoiceDetail() {
                         placeholder="Açıklama"
                     />
 
+                    <input
+                        type="date"
+                        name="dueDate"
+                        value={dayjs(form.dueDate).format("YYYY-MM-DD")}
+                        onChange={handleChange}
+                        className="w-full border px-3 py-2 rounded"
+                    />
+
+                    <input
+                        type="number"
+                        name="taxRate"
+                        value={form.taxRate || 0}
+                        onChange={handleChange}
+                        className="w-full border px-3 py-2 rounded"
+                        placeholder="Vergi Oranı"
+                    />
+
+                    <input
+                        type="text"
+                        name="paymentMethod"
+                        value={form.paymentMethod || ""}
+                        onChange={handleChange}
+                        className="w-full border px-3 py-2 rounded"
+                        placeholder="Ödeme Yöntemi"
+                    />
+
+                    <textarea
+                        name="note"
+                        value={form.note || ""}
+                        onChange={handleChange}
+                        className="w-full border px-3 py-2 rounded"
+                        rows="3"
+                        placeholder="Not"
+                    />
+
                     <select
                         name="status"
                         value={form.status}
@@ -151,6 +186,21 @@ function InvoiceDetail() {
                     <p>
                         <strong>Açıklama:</strong> {invoice.description}
                     </p>
+                    <p>
+                        <strong>Son Ödeme:</strong>{" "}
+                        {dayjs(invoice.dueDate).format("DD.MM.YYYY")}
+                    </p>
+                    <p>
+                        <strong>Vergi Oranı:</strong> {invoice.taxRate || 0}%
+                    </p>
+                    <p>
+                        <strong>Ödeme Yöntemi:</strong> {invoice.paymentMethod}
+                    </p>
+                    {invoice.note && (
+                        <p>
+                            <strong>Not:</strong> {invoice.note}
+                        </p>
+                    )}
                     <p>
                         <strong>Durum:</strong>{" "}
                         {invoice.status === "PAID" ? "Ödenmiş" : "Ödenmemiş"}


### PR DESCRIPTION
## Summary
- create CustomerDetail page with invoice list
- link to CustomerDetail from router and customer list
- allow editing dueDate, taxRate, paymentMethod and note in InvoiceDetail
- persist all invoice fields in backend updateInvoice
- fix backend tests for wrapper response and missing mocks

## Testing
- `./mvnw test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6846ebe00ab4832e91ce105e5cdfb68d