### PR TITLE
Add customer detail page, make invoices fully editable

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,15 @@ Finolo, küçük ve orta ölçekli işletmeler için geliştirilen modern, hızl
 - [x] Müşteri ve fatura yönetimi ekranları
 - [x] Reusable bileşen yapısı (Cards, Charts, Modals)
 - [x] Mobil uyumlu tasarım
+- [x] İlk girişte açılan kısa yardım rehberi
 
 ---
 
 ## 🚧 Yapılacaklar
 
-### Teknik
+-### Teknik
 - [ ] Rol bazlı yetkilendirme (ADMIN / USER)
-- [ ] Gelişmiş form validasyonları (zaman, tutar, email)
+- [x] Gelişmiş form validasyonları (zaman, tutar, email)
 - [ ] Export (PDF/Excel) özellikleri
 - [ ] Hata yönetimi için global logging sistemi
 - [ ] E-posta bildirim altyapısı (kayıt sonrası vs)
@@ -67,6 +68,10 @@ cd frontend
 npm install
 npm run dev
 ```
+
+### Yardım Rehberi
+
+Uygulamaya ilk kez girdiğinizde kısa bir rehber görünür. Rehber kapatıldığında tarayıcınızda `tutorialShown` anahtarı kaydedilir. Tekrar görmek isterseniz bu anahtarı silmeniz yeterlidir.
 
 ---
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -39,6 +39,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
         </dependency>

--- a/backend/src/main/java/com/finolo/config/SecurityConfig.java
+++ b/backend/src/main/java/com/finolo/config/SecurityConfig.java
@@ -30,6 +30,9 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/h2-console/**", "/api/auth/**").permitAll()
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/api/invoices/**", "/api/customers/**", "/api/dashboard/**", "/api/user/**")
+                            .hasRole("USER")
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)

--- a/backend/src/main/java/com/finolo/controller/dashboard/DashboardController.java
+++ b/backend/src/main/java/com/finolo/controller/dashboard/DashboardController.java
@@ -2,6 +2,7 @@ package com.finolo.controller.dashboard;
 
 import com.finolo.dto.common.BaseResponse;
 import com.finolo.dto.dashboard.DashboardSummaryResponse;
+import com.finolo.dto.dashboard.OperationResponse;
 import com.finolo.dto.invoice.InvoiceResponse;
 import com.finolo.service.dashboard.DashboardService;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +43,12 @@ public class DashboardController {
     public ResponseEntity<BaseResponse<Map<String, Long>>> getPaymentStats() {
         var stats = dashboardService.getPaymentStats();
         return ResponseEntity.ok(BaseResponse.success(stats, "Tahsilat durumu getirildi"));
+    }
+
+    @GetMapping("/operations")
+    public ResponseEntity<BaseResponse<List<OperationResponse>>> getOperations() {
+        var ops = dashboardService.getRecentOperations();
+        return ResponseEntity.ok(BaseResponse.success(ops, "Son işlemler getirildi"));
     }
 
 

--- a/backend/src/main/java/com/finolo/dto/auth/RegisterRequest.java
+++ b/backend/src/main/java/com/finolo/dto/auth/RegisterRequest.java
@@ -16,4 +16,7 @@ public class RegisterRequest {
 
     @NotBlank(message = "İşletme adı boş olamaz")
     private String businessName;
+
+    // optional, defaults to USER if not provided
+    private String role;
 }

--- a/backend/src/main/java/com/finolo/dto/dashboard/OperationResponse.java
+++ b/backend/src/main/java/com/finolo/dto/dashboard/OperationResponse.java
@@ -1,0 +1,18 @@
+package com.finolo.dto.dashboard;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OperationResponse {
+    private String type;
+    private String message;
+    private LocalDate date;
+}

--- a/backend/src/main/java/com/finolo/repository/CustomerRepository.java
+++ b/backend/src/main/java/com/finolo/repository/CustomerRepository.java
@@ -10,4 +10,5 @@ public interface CustomerRepository extends JpaRepository<Customer, Long> {
     List<Customer> findByUser(User user);
     List<Customer> findAllByUser_Email(String email);
     int countByUser(User user);
+    List<Customer> findTop5ByUserOrderByIdDesc(User user);
 }

--- a/backend/src/main/java/com/finolo/repository/InvoiceRepository.java
+++ b/backend/src/main/java/com/finolo/repository/InvoiceRepository.java
@@ -17,6 +17,7 @@ public interface InvoiceRepository extends JpaRepository<Invoice, Long> {
     @Query("SELECT SUM(i.amount) FROM Invoice i WHERE i.user = :user")
     Optional<Double> sumAmountByUser(@Param("user") User user);
     List<Invoice> findTop5ByUserOrderByDateDesc(User user);
+    List<Invoice> findTop5ByUserOrderByCreatedAtDesc(User user);
     List<Invoice> findByUserAndDateAfter(User user, LocalDate date);
 
 

--- a/backend/src/main/java/com/finolo/service/auth/AuthService.java
+++ b/backend/src/main/java/com/finolo/service/auth/AuthService.java
@@ -6,6 +6,7 @@ import com.finolo.dto.auth.RegisterRequest;
 import com.finolo.model.User;
 import com.finolo.repository.UserRepository;
 import com.finolo.security.JwtService;
+import com.finolo.service.mail.MailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -19,6 +20,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtService jwtService;
+    private final MailService mailService;
 
     public AuthResponse register(RegisterRequest request) {
         if (userRepository.existsByEmail(request.getEmail())) {
@@ -29,10 +31,13 @@ public class AuthService {
                 .email(request.getEmail())
                 .password(passwordEncoder.encode(request.getPassword()))
                 .businessName(request.getBusinessName())
-                .role("USER")
+                .role(request.getRole() != null ? request.getRole() : "USER")
                 .build();
 
         userRepository.save(user);
+
+        // Yeni kullanıcıya hoş geldiniz e-postası gönder
+        mailService.sendWelcomeMail(user.getEmail());
 
         String token = jwtService.generateToken(user.getUsername());
 

--- a/backend/src/main/java/com/finolo/service/invoice/InvoiceService.java
+++ b/backend/src/main/java/com/finolo/service/invoice/InvoiceService.java
@@ -137,6 +137,14 @@ public class InvoiceService {
         invoice.setAmount(request.getAmount());
         invoice.setDescription(request.getDescription());
         invoice.setStatus(request.getStatus());
+        invoice.setDueDate(request.getDueDate());
+        invoice.setTaxRate(request.getTaxRate());
+        invoice.setPaymentMethod(request.getPaymentMethod());
+        invoice.setNote(request.getNote());
+
+        double taxRate = request.getTaxRate() != null ? request.getTaxRate() : 0.0;
+        invoice.setTotalWithTax(request.getAmount() * (1 + (taxRate / 100.0)));
+
         invoice.setCustomer(customer);
 
         Invoice updated = invoiceRepository.save(invoice);

--- a/backend/src/main/java/com/finolo/service/mail/MailService.java
+++ b/backend/src/main/java/com/finolo/service/mail/MailService.java
@@ -1,0 +1,21 @@
+package com.finolo.service.mail;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+    private final JavaMailSender mailSender;
+
+    public void sendWelcomeMail(String to) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setSubject("Finolo'ya Hoş Geldiniz!");
+        message.setText("Finolo'ya kayıt olduğunuz için teşekkür ederiz.");
+        mailSender.send(message);
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -8,3 +8,11 @@ spring.web.resources.add-mappings=false
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.ddl-auto=update
 spring.h2.console.enabled=true
+
+# SMTP configuration
+spring.mail.host=smtp.example.com
+spring.mail.port=587
+spring.mail.username=no-reply@example.com
+spring.mail.password=change-me
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true

--- a/backend/src/test/java/com/finolo/controller/auth/AuthControllerTest.java
+++ b/backend/src/test/java/com/finolo/controller/auth/AuthControllerTest.java
@@ -61,6 +61,23 @@ class AuthControllerTest {
     }
 
     @Test
+    void shouldReturnError_WhenRegistrationFails() throws Exception {
+        RegisterRequest request = new RegisterRequest();
+        request.setEmail("exists@finolo.com");
+        request.setPassword("123456");
+        request.setBusinessName("Finolo");
+
+        when(authService.register(any())).thenThrow(new RuntimeException("Bu e-posta zaten kayıtlı."));
+
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("Bu e-posta zaten kayıtlı."));
+    }
+
+    @Test
     void shouldLoginSuccessfully() throws Exception {
         LoginRequest request = new LoginRequest();
         request.setEmail("login@finolo.com");

--- a/backend/src/test/java/com/finolo/controller/invoice/InvoiceControllerTest.java
+++ b/backend/src/test/java/com/finolo/controller/invoice/InvoiceControllerTest.java
@@ -89,8 +89,8 @@ class InvoiceControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(invoiceRequest)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.invoiceNumber").value("INV-TEST-123456"))
-                .andExpect(jsonPath("$.amount").value(2500.0));
+                .andExpect(jsonPath("$.data.invoiceNumber").value("INV-TEST-123456"))
+                .andExpect(jsonPath("$.data.amount").value(2500.0));
     }
 
     @Test
@@ -100,8 +100,8 @@ class InvoiceControllerTest {
 
         mockMvc.perform(get("/api/invoices"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].invoiceNumber").value("INV-TEST-123456"))
-                .andExpect(jsonPath("$[0].amount").value(2500.0))
-                .andExpect(jsonPath("$[0].status").value("DRAFT"));
+                .andExpect(jsonPath("$.data[0].invoiceNumber").value("INV-TEST-123456"))
+                .andExpect(jsonPath("$.data[0].amount").value(2500.0))
+                .andExpect(jsonPath("$.data[0].status").value("DRAFT"));
     }
 }

--- a/backend/src/test/java/com/finolo/service/auth/AuthServiceTest.java
+++ b/backend/src/test/java/com/finolo/service/auth/AuthServiceTest.java
@@ -3,6 +3,7 @@ package com.finolo.service.auth;
 import com.finolo.dto.auth.RegisterRequest;
 import com.finolo.model.User;
 import com.finolo.repository.UserRepository;
+import com.finolo.security.JwtService;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -25,6 +26,9 @@ class AuthServiceTest {
     @Mock
     private PasswordEncoder passwordEncoder;
 
+    @Mock
+    private JwtService jwtService;
+
     @InjectMocks
     private AuthService authService;
 
@@ -44,6 +48,7 @@ class AuthServiceTest {
 
         when(userRepository.existsByEmail("test@example.com")).thenReturn(false);
         when(passwordEncoder.encode("password123")).thenReturn("hashed-pass");
+        when(jwtService.generateToken(any())).thenReturn("mock-token");
 
         var response = authService.register(request);
 

--- a/backend/src/test/java/com/finolo/service/auth/AuthServiceTest.java
+++ b/backend/src/test/java/com/finolo/service/auth/AuthServiceTest.java
@@ -3,6 +3,7 @@ package com.finolo.service.auth;
 import com.finolo.dto.auth.RegisterRequest;
 import com.finolo.model.User;
 import com.finolo.repository.UserRepository;
+import com.finolo.service.mail.MailService;
 import com.finolo.security.JwtService;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
@@ -27,6 +28,9 @@ class AuthServiceTest {
     private PasswordEncoder passwordEncoder;
 
     @Mock
+    private MailService mailService;
+
+    @Mock
     private JwtService jwtService;
 
     @InjectMocks
@@ -48,13 +52,14 @@ class AuthServiceTest {
 
         when(userRepository.existsByEmail("test@example.com")).thenReturn(false);
         when(passwordEncoder.encode("password123")).thenReturn("hashed-pass");
-        when(jwtService.generateToken(any())).thenReturn("mock-token");
+        when(jwtService.generateToken(any())).thenReturn("jwt-token");
 
         var response = authService.register(request);
 
         assertThat(response.getEmail()).isEqualTo("test@example.com");
         assertThat(response.getRole()).isEqualTo("USER");
         verify(userRepository, times(1)).save(any(User.class));
+        verify(mailService, times(1)).sendWelcomeMail("test@example.com");
     }
 
     @Test
@@ -71,5 +76,7 @@ class AuthServiceTest {
         assertThat(exception.getMessage()).isEqualTo("Bu e-posta zaten kayıtlı.");
 
         verify(userRepository, never()).save(any());
+        verify(mailService, never()).sendWelcomeMail(any());
+        verify(jwtService, never()).generateToken(any());
     }
 }

--- a/backend/src/test/java/com/finolo/service/dashboard/DashboardServiceTest.java
+++ b/backend/src/test/java/com/finolo/service/dashboard/DashboardServiceTest.java
@@ -1,0 +1,63 @@
+package com.finolo.service.dashboard;
+
+import com.finolo.dto.dashboard.OperationResponse;
+import com.finolo.mapper.InvoiceMapper;
+import com.finolo.model.Customer;
+import com.finolo.model.Invoice;
+import com.finolo.model.User;
+import com.finolo.repository.CustomerRepository;
+import com.finolo.repository.InvoiceRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+
+class DashboardServiceTest {
+
+    @Mock
+    private InvoiceRepository invoiceRepository;
+    @Mock
+    private CustomerRepository customerRepository;
+
+    @InjectMocks
+    private DashboardService dashboardService;
+
+    private User user;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        dashboardService = new DashboardService(invoiceRepository, customerRepository, new InvoiceMapper());
+        user = User.builder().id(1L).email("test@finolo.com").build();
+        SecurityContext context = org.mockito.Mockito.mock(SecurityContext.class);
+        when(context.getAuthentication()).thenReturn(new UsernamePasswordAuthenticationToken(user, null));
+        SecurityContextHolder.setContext(context);
+    }
+
+    @Test
+    void testGetRecentOperations() {
+        Invoice inv = Invoice.builder()
+                .id(1L)
+                .createdAt(LocalDate.now())
+                .invoiceNumber("INV-1")
+                .customer(Customer.builder().name("Ali").build())
+                .build();
+
+        when(invoiceRepository.findTop5ByUserOrderByCreatedAtDesc(user)).thenReturn(List.of(inv));
+        when(customerRepository.findTop5ByUserOrderByIdDesc(user)).thenReturn(List.of(Customer.builder().name("Veli").build()));
+
+        List<OperationResponse> ops = dashboardService.getRecentOperations();
+        assertEquals(2, ops.size());
+        assertEquals("INVOICE", ops.get(0).getType());
+    }
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,8 @@
         "react-dom": "^19.0.0",
         "react-icons": "^5.5.0",
         "react-router-dom": "^6.30.0",
-        "recharts": "^2.15.3"
+        "recharts": "^2.15.3",
+        "yup": "^1.6.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
@@ -4772,6 +4773,12 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/property-expr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -5631,6 +5638,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
+      "license": "MIT"
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -5676,6 +5689,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
+      "license": "MIT"
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -5694,6 +5713,18 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -6034,6 +6065,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yup": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.6.1.tgz",
+      "integrity": "sha512-JED8pB50qbA4FOkDol0bYF/p60qSEDQqBD0/qeIrUCG1KbPBIQ776fCUNb9ldbPcSTxA69g/47XTo4TqWiuXOA==",
+      "license": "MIT",
+      "dependencies": {
+        "property-expr": "^2.0.5",
+        "tiny-case": "^1.0.3",
+        "toposort": "^2.0.2",
+        "type-fest": "^2.19.0"
       }
     },
     "node_modules/zod": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,8 @@
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",
     "react-router-dom": "^6.30.0",
-    "recharts": "^2.15.3"
+    "recharts": "^2.15.3",
+    "yup": "^1.6.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import Login from "./pages/Login";
 import Register from "./pages/Register";
 import Dashboard from "./pages/Dashboard";
 import Customers from "./pages/Customers";
+import CustomerForm from "./pages/CustomerForm.jsx";
 import CustomerDetail from "./pages/CustomerDetail";
 import Profile from "./pages/Profile";
 import PrivateRoute from "./routes/PrivateRoute";
@@ -10,6 +11,7 @@ import Layout from "./components/Layout.jsx";
 import Invoices from "./pages/Invoices.jsx";
 import InvoiceForm from "./pages/InvoiceForm.jsx";
 import InvoiceDetail from "./pages/InvoiceDetail";
+import AdminPanel from "./pages/AdminPanel.jsx";
 
 function App() {
     return (
@@ -23,12 +25,13 @@ function App() {
                 <Route element={<PrivateRoute><Layout /></PrivateRoute>}>
                     <Route path="/dashboard" element={<Dashboard />} />
                     <Route path="/customers" element={<Customers />} />
-                    <Route path="/customers/new" element={<Customers />} />
+                    <Route path="/customers/new" element={<CustomerForm />} />
                     <Route path="/customers/:id" element={<CustomerDetail />} />
                     <Route path="/profile" element={<Profile />} />
                     <Route path="/invoices" element={<Invoices />} />
                     <Route path="/invoices/:id" element={<InvoiceDetail />} />
                     <Route path="/invoice/new" element={<InvoiceForm />} />
+                    <Route path="/admin" element={<AdminPanel />} />
                 </Route>
             </Routes>
         </Router>

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,6 +3,7 @@ import Login from "./pages/Login";
 import Register from "./pages/Register";
 import Dashboard from "./pages/Dashboard";
 import Customers from "./pages/Customers";
+import CustomerDetail from "./pages/CustomerDetail";
 import Profile from "./pages/Profile";
 import PrivateRoute from "./routes/PrivateRoute";
 import Layout from "./components/Layout.jsx";
@@ -23,6 +24,7 @@ function App() {
                     <Route path="/dashboard" element={<Dashboard />} />
                     <Route path="/customers" element={<Customers />} />
                     <Route path="/customers/new" element={<Customers />} />
+                    <Route path="/customers/:id" element={<CustomerDetail />} />
                     <Route path="/profile" element={<Profile />} />
                     <Route path="/invoices" element={<Invoices />} />
                     <Route path="/invoices/:id" element={<InvoiceDetail />} />

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,9 +1,25 @@
 import Navbar from "./Navbar";
 import {Outlet} from "react-router-dom";
+import {useEffect, useState} from "react";
+import TutorialOverlay from "./TutorialOverlay";
 
 function Layout() {
+    const [showTutorial, setShowTutorial] = useState(false);
+
+    useEffect(() => {
+        if (!localStorage.getItem("tutorialShown")) {
+            setShowTutorial(true);
+        }
+    }, []);
+
+    const closeTutorial = () => {
+        localStorage.setItem("tutorialShown", "true");
+        setShowTutorial(false);
+    };
+
     return (
-        <div className="flex flex-col min-h-screen bg-gray-100">
+        <div className="flex flex-col min-h-screen bg-gray-100 dark:bg-gray-900 dark:text-gray-100">
+            {showTutorial && <TutorialOverlay onClose={closeTutorial} />}
             <Navbar />
             <main className="flex-1 px-4 py-6 max-w-7xl mx-auto w-full">
                 <Outlet />

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,4 +1,4 @@
-import {NavLink, useNavigate} from "react-router-dom";
+import {NavLink, useNavigate, useLocation} from "react-router-dom";
 import {useAuth} from "../context/AuthContext";
 import {useEffect, useState} from "react";
 import {useTheme} from "../context/ThemeContext.jsx";
@@ -7,6 +7,7 @@ import {Sun, Moon} from "lucide-react";
 function Navbar() {
     const { user, logout } = useAuth();
     const navigate = useNavigate();
+    const location = useLocation();
     const [menuOpen, setMenuOpen] = useState(false);
     const { theme, toggleTheme } = useTheme();
 

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,11 +1,14 @@
 import {NavLink, useNavigate} from "react-router-dom";
 import {useAuth} from "../context/AuthContext";
 import {useEffect, useState} from "react";
+import {useTheme} from "../context/ThemeContext.jsx";
+import {Sun, Moon} from "lucide-react";
 
 function Navbar() {
     const { user, logout } = useAuth();
     const navigate = useNavigate();
     const [menuOpen, setMenuOpen] = useState(false);
+    const { theme, toggleTheme } = useTheme();
 
     useEffect(() => {
         setMenuOpen(false); // rota değişince menü kapansın
@@ -13,11 +16,11 @@ function Navbar() {
 
     const linkClasses = ({ isActive }) =>
         isActive
-            ? "text-indigo-600 font-semibold"
-            : "text-gray-700 hover:text-indigo-600";
+            ? "text-indigo-600 dark:text-indigo-400 font-semibold"
+            : "text-gray-700 dark:text-gray-200 hover:text-indigo-600";
 
     return (
-        <nav className="bg-white border-b shadow-sm p-4 flex items-center justify-between relative z-50">
+        <nav className="bg-white dark:bg-gray-800 border-b dark:border-gray-700 shadow-sm p-4 flex items-center justify-between relative z-50">
             <div className="text-xl font-bold text-indigo-600 cursor-pointer" onClick={() => navigate("/dashboard")}>
                 Finolo
             </div>
@@ -25,12 +28,23 @@ function Navbar() {
             {/* Masaüstü Menü */}
             <div className="hidden md:flex gap-6 items-center">
                 <NavLink to="/dashboard" className={linkClasses}>Dashboard</NavLink>
-                <NavLink to="/customers" className={linkClasses}>Müşteriler</NavLink>
+                {user?.role === "USER" && (
+                    <>
+                        <NavLink to="/customers" className={linkClasses}>Müşteriler</NavLink>
+                        <NavLink to="/invoices" className={linkClasses}>Faturalar</NavLink>
+                    </>
+                )}
+                {user?.role === "ADMIN" && (
+                    <NavLink to="/admin" className={linkClasses}>Admin</NavLink>
+                )}
                 <NavLink to="/profile" className={linkClasses}>Profil</NavLink>
             </div>
 
             <div className="hidden md:flex items-center gap-4">
-                <span className="text-sm text-gray-600">{user?.email}</span>
+                <button onClick={toggleTheme} className="text-xl">
+                    {theme === "dark" ? <Sun /> : <Moon />}
+                </button>
+                <span className="text-sm text-gray-600 dark:text-gray-300">{user?.email}</span>
                 <button
                     onClick={() => {
                         logout();
@@ -44,7 +58,7 @@ function Navbar() {
 
             {/* Hamburger */}
             <div className="md:hidden">
-                <button onClick={() => setMenuOpen(!menuOpen)} className="text-indigo-600 text-2xl">
+                <button onClick={() => setMenuOpen(!menuOpen)} className="text-indigo-600 dark:text-indigo-400 text-2xl">
                     ☰
                 </button>
             </div>
@@ -52,7 +66,7 @@ function Navbar() {
             {/* Mobil Menü */}
             <div
                 className={`
-          fixed top-0 left-0 w-full h-screen bg-white/90 backdrop-blur-md transition-transform duration-300 ease-in-out
+          fixed top-0 left-0 w-full h-screen bg-white/90 dark:bg-gray-900/90 backdrop-blur-md transition-transform duration-300 ease-in-out
           flex flex-col z-40 px-6 py-4
           ${menuOpen ? "translate-x-0" : "-translate-x-full"}
         `}
@@ -61,20 +75,31 @@ function Navbar() {
           <h2 className="text-xl font-bold text-indigo-600">Finolo</h2>
           <button
             onClick={() => setMenuOpen(false)}
-            className="text-2xl text-gray-700 hover:text-indigo-600"
+            className="text-2xl text-gray-700 dark:text-gray-200 hover:text-indigo-600"
           >
             ✕
           </button>
         </div>
 
-        <nav className="flex flex-col gap-4 text-lg text-gray-700">
+        <nav className="flex flex-col gap-4 text-lg text-gray-700 dark:text-gray-200">
           <NavLink to="/dashboard" className={linkClasses}>Dashboard</NavLink>
-          <NavLink to="/customers" className={linkClasses}>Müşteriler</NavLink>
-            <NavLink to="/invoices" className={linkClasses}>Faturalar</NavLink>
-            <NavLink to="/profile" className={linkClasses}>Profil</NavLink>
+          {user?.role === "USER" && (
+            <>
+              <NavLink to="/customers" className={linkClasses}>Müşteriler</NavLink>
+              <NavLink to="/invoices" className={linkClasses}>Faturalar</NavLink>
+            </>
+          )}
+          {user?.role === "ADMIN" && (
+            <NavLink to="/admin" className={linkClasses}>Admin</NavLink>
+          )}
+          <NavLink to="/profile" className={linkClasses}>Profil</NavLink>
         </nav>
 
-        <div className="mt-auto pt-6 border-t text-sm text-gray-600">
+        <div className="mt-auto pt-6 border-t text-sm text-gray-600 dark:text-gray-300">
+          <button onClick={toggleTheme} className="mb-4 flex items-center gap-2">
+            {theme === "dark" ? <Sun size={18} /> : <Moon size={18} />}
+            <span>Temayı Değiştir</span>
+          </button>
           <p className="mb-2">{user?.email}</p>
           <button
             onClick={() => {

--- a/frontend/src/components/TutorialOverlay.jsx
+++ b/frontend/src/components/TutorialOverlay.jsx
@@ -1,0 +1,35 @@
+import {useState} from "react";
+
+function TutorialOverlay({ onClose }) {
+    const steps = [
+        { title: "Hoş Geldiniz", text: "Dashboard'da özet finans verilerini inceleyebilirsiniz." },
+        { title: "Müşteriler", text: "Müşteri kayıtlarınızı ve bilgilerini yönetin." },
+        { title: "Faturalar", text: "Yeni faturalar oluşturup geçmiş işlemleri takip edin." }
+    ];
+    const [index, setIndex] = useState(0);
+
+    const next = () => {
+        if (index < steps.length - 1) {
+            setIndex(index + 1);
+        } else {
+            onClose();
+        }
+    };
+
+    return (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+            <div className="bg-white p-6 rounded shadow max-w-md w-full text-center">
+                <h2 className="text-xl font-bold mb-2">{steps[index].title}</h2>
+                <p className="mb-4">{steps[index].text}</p>
+                <button
+                    onClick={next}
+                    className="bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700"
+                >
+                    {index < steps.length - 1 ? "Devam" : "Kapat"}
+                </button>
+            </div>
+        </div>
+    );
+}
+
+export default TutorialOverlay;

--- a/frontend/src/context/ThemeContext.jsx
+++ b/frontend/src/context/ThemeContext.jsx
@@ -1,0 +1,32 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+const ThemeContext = createContext();
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState(() =>
+    localStorage.getItem("theme") || "light"
+  );
+
+  useEffect(() => {
+    localStorage.setItem("theme", theme);
+    if (theme === "dark") {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === "light" ? "dark" : "light"));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,9 +3,12 @@ import ReactDOM from "react-dom/client";
 import App from "./App.jsx";
 import "./index.css";
 import {AuthProvider} from "./context/AuthContext.jsx";
+import {ThemeProvider} from "./context/ThemeContext.jsx";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
-        <AuthProvider>
-            <App />
-        </AuthProvider>
+  <ThemeProvider>
+    <AuthProvider>
+      <App />
+    </AuthProvider>
+  </ThemeProvider>
 );

--- a/frontend/src/pages/AdminPanel.jsx
+++ b/frontend/src/pages/AdminPanel.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+function AdminPanel() {
+    return (
+        <div className="p-4">
+            <h2 className="text-2xl font-bold text-indigo-600">Admin Panel</h2>
+            <p>Yalnızca yöneticiler için erişilebilir.</p>
+        </div>
+    );
+}
+
+export default AdminPanel;

--- a/frontend/src/pages/CustomerDetail.jsx
+++ b/frontend/src/pages/CustomerDetail.jsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { getCustomers } from "../services/customerService";
+import { getInvoices } from "../services/invoiceService";
+import { formatDate } from "../utils/dateUtils";
+import { ArrowLeft } from "lucide-react";
+
+function CustomerDetail() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+
+  const [customer, setCustomer] = useState(null);
+  const [invoices, setInvoices] = useState([]);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const customerList = await getCustomers();
+        const found = customerList.find((c) => String(c.id) === String(id));
+        setCustomer(found);
+
+        const invRes = await getInvoices();
+        if (invRes.success) {
+          const related = invRes.data.filter((inv) => inv.customerId === Number(id));
+          setInvoices(related);
+        }
+      } catch (err) {
+        setError("Veriler alınamadı.");
+      }
+    };
+
+    fetchData();
+  }, [id]);
+
+  if (!customer) return <p className="text-center text-gray-500">Yükleniyor...</p>;
+
+  return (
+    <div className="max-w-2xl mx-auto bg-white p-6 rounded shadow mt-6">
+      <button
+        onClick={() => navigate("/customers")}
+        className="mb-4 text-sm text-gray-600 hover:text-indigo-600 flex items-center"
+      >
+        <ArrowLeft className="w-4 h-4 mr-1" />
+        Müşterilere Dön
+      </button>
+
+      <h2 className="text-xl font-bold text-indigo-600 mb-4">Müşteri Detayı</h2>
+
+      <div className="space-y-1 text-sm mb-6">
+        <p>
+          <strong>Ad:</strong> {customer.name}
+        </p>
+        <p>
+          <strong>Email:</strong> {customer.email}
+        </p>
+        <p>
+          <strong>Telefon:</strong> {customer.phone}
+        </p>
+        <p>
+          <strong>Adres:</strong> {customer.address}
+        </p>
+      </div>
+
+      <h3 className="text-lg font-semibold text-indigo-600 mb-2">Faturalar</h3>
+      {invoices.length > 0 ? (
+        <table className="w-full text-sm">
+          <thead className="bg-gray-100 text-left">
+            <tr>
+              <th className="px-4 py-2">Fatura No</th>
+              <th className="px-4 py-2">Tarih</th>
+              <th className="px-4 py-2">Tutar</th>
+              <th className="px-4 py-2">Durum</th>
+            </tr>
+          </thead>
+          <tbody>
+            {invoices.map((inv) => (
+              <tr key={inv.id} className="border-b">
+                <td className="px-4 py-2">{inv.invoiceNumber}</td>
+                <td className="px-4 py-2">{formatDate(inv.date)}</td>
+                <td className="px-4 py-2">{inv.amount} ₺</td>
+                <td className="px-4 py-2">
+                  {inv.status === "PAID" ? "Ödenmiş" : "Ödenmemiş"}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      ) : (
+        <p className="text-sm text-gray-500">Bu müşteriye ait fatura bulunmuyor.</p>
+      )}
+
+      {error && <p className="text-red-500 text-sm mt-4">{error}</p>}
+    </div>
+  );
+}
+
+export default CustomerDetail;

--- a/frontend/src/pages/CustomerDetail.jsx
+++ b/frontend/src/pages/CustomerDetail.jsx
@@ -26,6 +26,7 @@ function CustomerDetail() {
           setInvoices(related);
         }
       } catch (err) {
+        console.error(err);
         setError("Veriler alınamadı.");
       }
     };

--- a/frontend/src/pages/CustomerForm.jsx
+++ b/frontend/src/pages/CustomerForm.jsx
@@ -1,10 +1,21 @@
 import {useState} from "react";
+import * as Yup from "yup";
 import {useNavigate} from "react-router-dom";
 import {createCustomer} from "../services/customerService.js";
 
 function CustomerForm() {
   const [form, setForm] = useState({ name: "", email: "", phone: "", address: "" });
+  const [errors, setErrors] = useState({});
   const navigate = useNavigate();
+
+  const schema = Yup.object().shape({
+    name: Yup.string().required("İsim gerekli"),
+    email: Yup.string().email("Geçerli bir email girin").required("Email gerekli"),
+    phone: Yup.string()
+      .matches(/^\+?\d{10,15}$/, "Geçerli bir telefon numarası girin")
+      .required("Telefon gerekli"),
+    address: Yup.string().required("Adres gerekli")
+  });
 
   const handleChange = (e) => {
     setForm({ ...form, [e.target.name]: e.target.value });
@@ -13,21 +24,74 @@ function CustomerForm() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
+      await schema.validate(form, { abortEarly: false });
       await createCustomer(form);
       navigate("/customers");
     } catch (error) {
-      console.error("Kayıt hatası:", error);
+      if (error instanceof Yup.ValidationError) {
+        const validationErrors = {};
+        error.inner.forEach((err) => {
+          if (err.path) validationErrors[err.path] = err.message;
+        });
+        setErrors(validationErrors);
+      } else {
+        console.error("Kayıt hatası:", error);
+      }
     }
   };
 
   return (
-    <div className="p-4 max-w-xl mx-auto">
+    <div className="p-4 max-w-xl mx-auto bg-white dark:bg-gray-800 rounded shadow">
       <h2 className="text-2xl font-bold mb-4">Yeni Müşteri</h2>
       <form onSubmit={handleSubmit} className="space-y-4">
-        <input type="text" name="name" placeholder="Ad Soyad" onChange={handleChange} className="w-full p-2 border rounded" />
-        <input type="email" name="email" placeholder="Email" onChange={handleChange} className="w-full p-2 border rounded" />
-        <input type="text" name="phone" placeholder="Telefon" onChange={handleChange} className="w-full p-2 border rounded" />
-        <input type="text" name="address" placeholder="Adres" onChange={handleChange} className="w-full p-2 border rounded" />
+        <div>
+          <input
+            type="text"
+            name="name"
+            placeholder="Ad Soyad"
+            onChange={handleChange}
+            className="w-full p-2 border rounded"
+            required
+          />
+          {errors.name && <p className="text-red-500 text-sm mt-1">{errors.name}</p>}
+        </div>
+
+        <div>
+          <input
+            type="email"
+            name="email"
+            placeholder="Email"
+            onChange={handleChange}
+            className="w-full p-2 border rounded"
+            required
+          />
+          {errors.email && <p className="text-red-500 text-sm mt-1">{errors.email}</p>}
+        </div>
+
+        <div>
+          <input
+            type="text"
+            name="phone"
+            placeholder="Telefon"
+            onChange={handleChange}
+            className="w-full p-2 border rounded"
+            required
+          />
+          {errors.phone && <p className="text-red-500 text-sm mt-1">{errors.phone}</p>}
+        </div>
+
+        <div>
+          <input
+            type="text"
+            name="address"
+            placeholder="Adres"
+            onChange={handleChange}
+            className="w-full p-2 border rounded"
+            required
+          />
+          {errors.address && <p className="text-red-500 text-sm mt-1">{errors.address}</p>}
+        </div>
+
         <button type="submit" className="w-full bg-indigo-600 text-white p-2 rounded">Kaydet</button>
       </form>
     </div>

--- a/frontend/src/pages/Customers.jsx
+++ b/frontend/src/pages/Customers.jsx
@@ -26,7 +26,7 @@ function Customers() {
           <div
             key={c.id}
             onClick={() => navigate(`/customers/${c.id}`)}
-            className="p-4 bg-white rounded shadow cursor-pointer hover:bg-gray-50"
+            className="p-4 bg-white dark:bg-gray-800 rounded shadow cursor-pointer hover:bg-gray-50"
           >
             <h3 className="text-lg font-semibold">{c.name}</h3>
             <p>{c.email}</p>

--- a/frontend/src/pages/Customers.jsx
+++ b/frontend/src/pages/Customers.jsx
@@ -23,7 +23,11 @@ function Customers() {
       <h2 className="text-2xl font-bold mb-4">Müşteriler</h2>
       <div className="grid grid-cols-1 gap-4">
         {customers.map((c) => (
-          <div key={c.id} className="p-4 bg-white rounded shadow">
+          <div
+            key={c.id}
+            onClick={() => navigate(`/customers/${c.id}`)}
+            className="p-4 bg-white rounded shadow cursor-pointer hover:bg-gray-50"
+          >
             <h3 className="text-lg font-semibold">{c.name}</h3>
             <p>{c.email}</p>
             <p>{c.phone}</p>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,5 +1,5 @@
 import React, {useEffect, useState} from "react";
-import {getDashboardSummary, getMonthlyStats, getPaymentStats, getRecentInvoices} from "../services/dashboardService";
+import {getDashboardSummary, getMonthlyStats, getPaymentStats, getRecentInvoices, getRecentOperations} from "../services/dashboardService";
 import DashboardCard from "../components/DashboardCard";
 import MonthlyBarChart from "../components/MonthlyBarChart";
 import PaymentDonutChart from "../components/PaymentDonutChart";
@@ -10,6 +10,7 @@ function Dashboard() {
     const [recentInvoices, setRecentInvoices] = useState([]);
     const [monthlyStats, setMonthlyStats] = useState([]);
     const [paymentStats, setPaymentStats] = useState({});
+    const [operations, setOperations] = useState([]);
     const [error, setError] = useState("");
 
     useEffect(() => {
@@ -30,9 +31,13 @@ function Dashboard() {
                     setMonthlyStats(chartData);
                 }
 
+                const opsData = await getRecentOperations();
+                if (opsData.success) setOperations(opsData.data);
+
                 const fetchPayments = await getPaymentStats();
                 if (fetchPayments.success) setPaymentStats(fetchPayments.data);
             } catch (err) {
+                console.error(err);
                 setError("Dashboard verileri alınamadı.");
             }
         };
@@ -55,7 +60,7 @@ function Dashboard() {
             )}
 
             {/* Son 5 Fatura */}
-            <div className="bg-white p-4 rounded shadow">
+            <div className="bg-white dark:bg-gray-800 p-4 rounded shadow">
                 <h2 className="text-lg font-semibold text-indigo-600 mb-4">Son Faturalar</h2>
                 {recentInvoices.length > 0 ? (
                     <table className="w-full text-sm">
@@ -70,7 +75,7 @@ function Dashboard() {
                         </thead>
                         <tbody>
                         {recentInvoices.map((inv) => (
-                            <tr key={inv.id} className="border-b hover:bg-gray-50">
+                            <tr key={inv.id} className="border-b hover:bg-gray-50 dark:hover:bg-gray-700">
                                 <td>{inv.invoiceNumber}</td>
                                 <td>{inv.customerName}</td>
                                 <td>{inv.date}</td>
@@ -85,14 +90,28 @@ function Dashboard() {
                 )}
             </div>
 
+            {/* Son İşlemler */}
+            <div className="bg-white p-4 rounded shadow">
+                <h2 className="text-lg font-semibold text-indigo-600 mb-4">Son İşlemler</h2>
+                {operations.length > 0 ? (
+                    <ul className="list-disc pl-5 space-y-1 text-sm">
+                        {operations.map((op, idx) => (
+                            <li key={idx}>{op.message}</li>
+                        ))}
+                    </ul>
+                ) : (
+                    <p className="text-gray-500">Kayıtlı işlem bulunamadı.</p>
+                )}
+            </div>
+
             {/* Grafik ve Tahsilat */}
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                <div className="bg-white p-4 rounded shadow md:col-span-2">
+                <div className="bg-white dark:bg-gray-800 p-4 rounded shadow md:col-span-2">
                     <h2 className="text-lg font-semibold text-indigo-600 mb-4">Aylık Fatura Gelirleri</h2>
                     <MonthlyBarChart data={monthlyStats} />
                 </div>
 
-                <div className="bg-white p-4 rounded shadow">
+                <div className="bg-white dark:bg-gray-800 p-4 rounded shadow">
                     <h2 className="text-lg font-semibold text-indigo-600 mb-4">Tahsilat Durumu</h2>
                     <PaymentDonutChart data={paymentStats} />
                 </div>

--- a/frontend/src/pages/InvoiceDetail.jsx
+++ b/frontend/src/pages/InvoiceDetail.jsx
@@ -29,6 +29,7 @@ function InvoiceDetail() {
                     setCustomers(customerData.data);
                 }
             } catch (err) {
+                console.error(err);
                 setError("Fatura detayları alınamadı.");
             }
         };
@@ -56,7 +57,7 @@ function InvoiceDetail() {
     if (!invoice) return <p className="text-center text-gray-500">Yükleniyor...</p>;
 
     return (
-        <div className="max-w-2xl mx-auto bg-white p-6 rounded shadow mt-6">
+        <div className="max-w-2xl mx-auto bg-white dark:bg-gray-800 p-6 rounded shadow mt-6">
             {/* Geri Butonu */}
             <button
                 onClick={() => navigate("/invoices")}

--- a/frontend/src/pages/InvoiceDetail.jsx
+++ b/frontend/src/pages/InvoiceDetail.jsx
@@ -110,6 +110,41 @@ function InvoiceDetail() {
                         placeholder="Açıklama"
                     />
 
+                    <input
+                        type="date"
+                        name="dueDate"
+                        value={dayjs(form.dueDate).format("YYYY-MM-DD")}
+                        onChange={handleChange}
+                        className="w-full border px-3 py-2 rounded"
+                    />
+
+                    <input
+                        type="number"
+                        name="taxRate"
+                        value={form.taxRate || 0}
+                        onChange={handleChange}
+                        className="w-full border px-3 py-2 rounded"
+                        placeholder="Vergi Oranı"
+                    />
+
+                    <input
+                        type="text"
+                        name="paymentMethod"
+                        value={form.paymentMethod || ""}
+                        onChange={handleChange}
+                        className="w-full border px-3 py-2 rounded"
+                        placeholder="Ödeme Yöntemi"
+                    />
+
+                    <textarea
+                        name="note"
+                        value={form.note || ""}
+                        onChange={handleChange}
+                        className="w-full border px-3 py-2 rounded"
+                        rows="3"
+                        placeholder="Not"
+                    />
+
                     <select
                         name="status"
                         value={form.status}
@@ -151,6 +186,21 @@ function InvoiceDetail() {
                     <p>
                         <strong>Açıklama:</strong> {invoice.description}
                     </p>
+                    <p>
+                        <strong>Son Ödeme:</strong>{" "}
+                        {dayjs(invoice.dueDate).format("DD.MM.YYYY")}
+                    </p>
+                    <p>
+                        <strong>Vergi Oranı:</strong> {invoice.taxRate || 0}%
+                    </p>
+                    <p>
+                        <strong>Ödeme Yöntemi:</strong> {invoice.paymentMethod}
+                    </p>
+                    {invoice.note && (
+                        <p>
+                            <strong>Not:</strong> {invoice.note}
+                        </p>
+                    )}
                     <p>
                         <strong>Durum:</strong>{" "}
                         {invoice.status === "PAID" ? "Ödenmiş" : "Ödenmemiş"}

--- a/frontend/src/pages/InvoiceForm.jsx
+++ b/frontend/src/pages/InvoiceForm.jsx
@@ -1,4 +1,5 @@
 import {useEffect, useState} from "react";
+import * as Yup from "yup";
 import {useNavigate} from "react-router-dom";
 import {getCustomers} from "../services/customerService";
 import {createInvoice} from "../services/invoiceService";
@@ -9,6 +10,7 @@ function InvoiceForm() {
     const [customers, setCustomers] = useState([]);
     const [error, setError] = useState("");
     const [showModal, setShowModal] = useState(false);
+    const [formErrors, setFormErrors] = useState({});
 
     const [formData, setFormData] = useState({
         amount: "",
@@ -20,6 +22,14 @@ function InvoiceForm() {
         taxRate: 0,
         note: "",
         paymentMethod: ""
+    });
+
+    const schema = Yup.object().shape({
+        amount: Yup.number().typeError("Tutar sayı olmalı").positive("Tutar pozitif olmalı").required("Tutar gerekli"),
+        date: Yup.date().required("Fatura tarihi gerekli"),
+        dueDate: Yup.date().nullable(),
+        description: Yup.string().required("Açıklama gerekli"),
+        customerId: Yup.string().required("Müşteri seçimi gerekli")
     });
 
     useEffect(() => {
@@ -49,22 +59,26 @@ function InvoiceForm() {
 
     const handleSubmit = async (e) => {
         e.preventDefault();
-        if (!formData.customerId) {
-            alert("Lütfen bir müşteri seçin.");
-            return;
-        }
-
         try {
+            await schema.validate(formData, { abortEarly: false });
             await createInvoice(formData);
             navigate("/invoices");
         } catch (err) {
-            console.error(err);
-            setError("Fatura oluşturulamadı.");
+            if (err instanceof Yup.ValidationError) {
+                const validationErrors = {};
+                err.inner.forEach((e) => {
+                    if (e.path) validationErrors[e.path] = e.message;
+                });
+                setFormErrors(validationErrors);
+            } else {
+                console.error(err);
+                setError("Fatura oluşturulamadı.");
+            }
         }
     };
 
     return (
-        <div className="max-w-2xl mx-auto mt-10 p-6 bg-white rounded shadow">
+        <div className="max-w-2xl mx-auto mt-10 p-6 bg-white dark:bg-gray-800 rounded shadow">
             <h2 className="text-2xl font-bold mb-6">Fatura Oluştur</h2>
             <form onSubmit={handleSubmit} className="space-y-5">
 
@@ -77,7 +91,11 @@ function InvoiceForm() {
                         onChange={handleChange}
                         className="w-full p-2 border rounded"
                         required
+                        min="0"
                     />
+                    {formErrors.amount && (
+                        <p className="text-red-500 text-sm mt-1">{formErrors.amount}</p>
+                    )}
                 </div>
 
                 <div>
@@ -90,6 +108,9 @@ function InvoiceForm() {
                         className="w-full p-2 border rounded"
                         required
                     />
+                    {formErrors.date && (
+                        <p className="text-red-500 text-sm mt-1">{formErrors.date}</p>
+                    )}
                 </div>
 
                 <div>
@@ -101,6 +122,9 @@ function InvoiceForm() {
                         onChange={handleChange}
                         className="w-full p-2 border rounded"
                     />
+                    {formErrors.dueDate && (
+                        <p className="text-red-500 text-sm mt-1">{formErrors.dueDate}</p>
+                    )}
                 </div>
 
                 <div>
@@ -113,6 +137,9 @@ function InvoiceForm() {
                         className="w-full p-2 border rounded"
                         required
                     />
+                    {formErrors.description && (
+                        <p className="text-red-500 text-sm mt-1">{formErrors.description}</p>
+                    )}
                 </div>
 
                 <div>
@@ -131,6 +158,9 @@ function InvoiceForm() {
                             </option>
                         ))}
                     </select>
+                    {formErrors.customerId && (
+                        <p className="text-red-500 text-sm mt-1">{formErrors.customerId}</p>
+                    )}
                 </div>
 
                 <div>

--- a/frontend/src/pages/Invoices.jsx
+++ b/frontend/src/pages/Invoices.jsx
@@ -39,8 +39,8 @@ function Invoices() {
         <div className="overflow-x-auto w-full">
             <h2 className="text-2xl font-bold text-indigo-600 mb-4">Faturalar</h2>
 
-            <table className="min-w-full w-full text-sm text-left text-gray-700 bg-white shadow rounded">
-                <thead className="bg-gray-100 text-sm text-gray-700">
+            <table className="min-w-full w-full text-sm text-left text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 shadow rounded">
+                <thead className="bg-gray-100 dark:bg-gray-700 text-sm text-gray-700 dark:text-gray-200">
                 <tr>
                     <th className="px-4 py-2 text-left">Fatura No</th>
                     <th className="px-4 py-2 text-left">Müşteri</th>

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -24,15 +24,16 @@ function Login() {
             login(data, data.token);
             navigate("/dashboard");
         } catch (err) {
+            console.error(err);
             setError("Giriş başarısız. Lütfen bilgilerinizi kontrol edin.");
         }
     };
 
     return (
-        <div className="min-h-screen flex flex-col justify-center items-center bg-gray-100 px-4">
+        <div className="min-h-screen flex flex-col justify-center items-center bg-gray-100 dark:bg-gray-900 px-4">
             <img src={finoloLogo} alt="Finolo Logo" className="w-32 mb-6" />
 
-            <div className="w-full max-w-md bg-white p-6 rounded shadow">
+            <div className="w-full max-w-md bg-white dark:bg-gray-800 p-6 rounded shadow">
                 <h2 className="text-xl font-semibold text-center text-indigo-600 mb-4">Giriş Yap</h2>
 
                 <form onSubmit={handleSubmit} className="space-y-4">

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -23,7 +23,7 @@ function Profile() {
     if (loading) return <div className="p-4">Yükleniyor...</div>;
 
     return (
-        <div className="max-w-md mx-auto mt-10 p-6 bg-white rounded shadow">
+        <div className="max-w-md mx-auto mt-10 p-6 bg-white dark:bg-gray-800 rounded shadow">
             <h2 className="text-2xl font-bold mb-4 text-indigo-600">Profil Bilgileri</h2>
             <div className="space-y-2">
                 <p><strong>Firma Adı:</strong> {user.businessName}</p>

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -29,15 +29,16 @@ function Register() {
             login(data, data.token); // otomatik giriş
             navigate("/dashboard");
         } catch (err) {
+            console.error(err);
             setError("Kayıt başarısız. Lütfen bilgilerinizi kontrol edin.");
         }
     };
 
     return (
-        <div className="min-h-screen flex flex-col justify-center items-center bg-gray-100 px-4">
+        <div className="min-h-screen flex flex-col justify-center items-center bg-gray-100 dark:bg-gray-900 px-4">
             <img src={finoloLogo} alt="Finolo Logo" className="w-32 mb-6" />
 
-            <div className="w-full max-w-md bg-white p-6 rounded shadow">
+            <div className="w-full max-w-md bg-white dark:bg-gray-800 p-6 rounded shadow">
                 <h2 className="text-xl font-semibold text-center text-indigo-600 mb-4">Kayıt Ol</h2>
 
                 <form onSubmit={handleSubmit} className="space-y-4">

--- a/frontend/src/services/dashboardService.js
+++ b/frontend/src/services/dashboardService.js
@@ -19,3 +19,8 @@ export const getPaymentStats = async () => {
     const res = await api.get("/dashboard/payment-stats");
     return res.data;
 };
+
+export const getRecentOperations = async () => {
+    const res = await api.get("/dashboard/operations");
+    return res.data;
+};

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -4,6 +4,7 @@ export default {
     "./index.html",
     "./src/**/*.{js,jsx,ts,tsx}",
   ],
+  darkMode: "class",
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Summary
- create CustomerDetail page with invoice list
- link to CustomerDetail from router and customer list
- allow editing dueDate, taxRate, paymentMethod and note in InvoiceDetail
- persist all invoice fields in backend updateInvoice
- fix backend tests for wrapper response and missing mocks

## Testing
- `./mvnw test`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6846ebe00ab4832e91ce105e5cdfb68d