### PR TITLE
Add invoice export feature with CORS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,15 @@ Finolo, küçük ve orta ölçekli işletmeler için geliştirilen modern, hızl
 - [x] Müşteri ve fatura yönetimi ekranları
 - [x] Reusable bileşen yapısı (Cards, Charts, Modals)
 - [x] Mobil uyumlu tasarım
+- [x] İlk girişte açılan kısa yardım rehberi
 
 ---
 
 ## 🚧 Yapılacaklar
 
-### Teknik
+-### Teknik
 - [ ] Rol bazlı yetkilendirme (ADMIN / USER)
-- [ ] Gelişmiş form validasyonları (zaman, tutar, email)
+- [x] Gelişmiş form validasyonları (zaman, tutar, email)
 - [ ] Export (PDF/Excel) özellikleri
 - [ ] Hata yönetimi için global logging sistemi
 - [ ] E-posta bildirim altyapısı (kayıt sonrası vs)
@@ -67,6 +68,10 @@ cd frontend
 npm install
 npm run dev
 ```
+
+### Yardım Rehberi
+
+Uygulamaya ilk kez girdiğinizde kısa bir rehber görünür. Rehber kapatıldığında tarayıcınızda `tutorialShown` anahtarı kaydedilir. Tekrar görmek isterseniz bu anahtarı silmeniz yeterlidir.
 
 ---
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -39,6 +39,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-mail</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
         </dependency>
@@ -94,6 +99,18 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
+        </dependency>
+
+        <!-- Export dependencies -->
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-ooxml</artifactId>
+            <version>5.2.3</version>
+        </dependency>
+        <dependency>
+            <groupId>com.itextpdf</groupId>
+            <artifactId>itextpdf</artifactId>
+            <version>5.5.13.2</version>
         </dependency>
 
 

--- a/backend/src/main/java/com/finolo/config/SecurityConfig.java
+++ b/backend/src/main/java/com/finolo/config/SecurityConfig.java
@@ -14,6 +14,11 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.config.Customizer;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import java.util.List;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 
@@ -28,8 +33,12 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
                 .csrf(AbstractHttpConfigurer::disable)
+                .cors(Customizer.withDefaults())
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/h2-console/**", "/api/auth/**").permitAll()
+                        .requestMatchers("/api/admin/**").hasRole("ADMIN")
+                        .requestMatchers("/api/invoices/**", "/api/customers/**", "/api/dashboard/**", "/api/user/**")
+                            .hasRole("USER")
                         .anyRequest().authenticated()
                 )
                 .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class)
@@ -55,5 +64,18 @@ public class SecurityConfig {
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("http://localhost:5173"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }

--- a/backend/src/main/java/com/finolo/config/SecurityConfig.java
+++ b/backend/src/main/java/com/finolo/config/SecurityConfig.java
@@ -18,6 +18,7 @@ import org.springframework.security.config.Customizer;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.http.HttpHeaders;
 import java.util.List;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
@@ -72,6 +73,7 @@ public class SecurityConfig {
         configuration.setAllowedOrigins(List.of("http://localhost:5173"));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
+        configuration.setExposedHeaders(List.of(HttpHeaders.CONTENT_DISPOSITION));
         configuration.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();

--- a/backend/src/main/java/com/finolo/controller/invoice/InvoiceController.java
+++ b/backend/src/main/java/com/finolo/controller/invoice/InvoiceController.java
@@ -6,12 +6,16 @@ import com.finolo.dto.invoice.InvoiceResponse;
 import com.finolo.service.invoice.InvoiceService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.nio.file.AccessDeniedException;
 import java.util.List;
 
+@CrossOrigin(origins = "http://localhost:5173")
 @RestController
 @RequestMapping("/api/invoices")
 @RequiredArgsConstructor
@@ -45,6 +49,26 @@ public class InvoiceController {
     public ResponseEntity<BaseResponse<InvoiceResponse>> updateInvoice(@PathVariable Long id, @RequestBody @Valid InvoiceRequest request) {
         InvoiceResponse updated = invoiceService.updateInvoice(id, request);
         return ResponseEntity.ok(BaseResponse.success(updated, "Fatura güncellendi"));
+    }
+
+    @GetMapping("/export/pdf")
+    public ResponseEntity<byte[]> exportPdf() {
+        byte[] data = invoiceService.exportInvoicesToPdf();
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        ContentDisposition.attachment().filename("invoices.pdf").build().toString())
+                .contentType(MediaType.APPLICATION_PDF)
+                .body(data);
+    }
+
+    @GetMapping("/export/excel")
+    public ResponseEntity<byte[]> exportExcel() {
+        byte[] data = invoiceService.exportInvoicesToExcel();
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION,
+                        ContentDisposition.attachment().filename("invoices.xlsx").build().toString())
+                .contentType(MediaType.parseMediaType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"))
+                .body(data);
     }
 
 }

--- a/backend/src/main/java/com/finolo/dto/auth/RegisterRequest.java
+++ b/backend/src/main/java/com/finolo/dto/auth/RegisterRequest.java
@@ -16,4 +16,7 @@ public class RegisterRequest {
 
     @NotBlank(message = "İşletme adı boş olamaz")
     private String businessName;
+
+    // optional, defaults to USER if not provided
+    private String role;
 }

--- a/backend/src/main/java/com/finolo/service/auth/AuthService.java
+++ b/backend/src/main/java/com/finolo/service/auth/AuthService.java
@@ -6,6 +6,7 @@ import com.finolo.dto.auth.RegisterRequest;
 import com.finolo.model.User;
 import com.finolo.repository.UserRepository;
 import com.finolo.security.JwtService;
+import com.finolo.service.mail.MailService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -19,6 +20,7 @@ public class AuthService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtService jwtService;
+    private final MailService mailService;
 
     public AuthResponse register(RegisterRequest request) {
         if (userRepository.existsByEmail(request.getEmail())) {
@@ -29,10 +31,13 @@ public class AuthService {
                 .email(request.getEmail())
                 .password(passwordEncoder.encode(request.getPassword()))
                 .businessName(request.getBusinessName())
-                .role("USER")
+                .role(request.getRole() != null ? request.getRole() : "USER")
                 .build();
 
         userRepository.save(user);
+
+        // Yeni kullanıcıya hoş geldiniz e-postası gönder
+        mailService.sendWelcomeMail(user.getEmail());
 
         String token = jwtService.generateToken(user.getUsername());
 

--- a/backend/src/main/java/com/finolo/service/invoice/InvoiceService.java
+++ b/backend/src/main/java/com/finolo/service/invoice/InvoiceService.java
@@ -9,12 +9,22 @@ import com.finolo.model.User;
 import com.finolo.repository.CustomerRepository;
 import com.finolo.repository.InvoiceRepository;
 import lombok.RequiredArgsConstructor;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import com.itextpdf.text.Document;
+import com.itextpdf.text.DocumentException;
+import com.itextpdf.text.pdf.PdfPTable;
+import com.itextpdf.text.pdf.PdfWriter;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 
 import java.nio.file.AccessDeniedException;
 import java.time.LocalDate;
 import java.util.List;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 
 @Service
 @RequiredArgsConstructor
@@ -141,6 +151,62 @@ public class InvoiceService {
 
         Invoice updated = invoiceRepository.save(invoice);
         return invoiceMapper.toResponse(updated);
+    }
+
+    public byte[] exportInvoicesToPdf() {
+        User currentUser = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        List<Invoice> invoices = invoiceRepository.findByUser(currentUser);
+        try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            Document document = new Document();
+            PdfWriter.getInstance(document, out);
+            document.open();
+            PdfPTable table = new PdfPTable(5);
+            table.addCell("Invoice No");
+            table.addCell("Customer");
+            table.addCell("Date");
+            table.addCell("Amount");
+            table.addCell("Status");
+            for (Invoice invoice : invoices) {
+                table.addCell(invoice.getInvoiceNumber());
+                table.addCell(invoice.getCustomer().getName());
+                table.addCell(invoice.getDate().toString());
+                table.addCell(String.valueOf(invoice.getAmount()));
+                table.addCell(invoice.getStatus());
+            }
+            document.add(table);
+            document.close();
+            return out.toByteArray();
+        } catch (DocumentException | IOException e) {
+            throw new RuntimeException("PDF oluşturulamadı", e);
+        }
+    }
+
+    public byte[] exportInvoicesToExcel() {
+        User currentUser = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        List<Invoice> invoices = invoiceRepository.findByUser(currentUser);
+        try (Workbook workbook = new XSSFWorkbook(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            Sheet sheet = workbook.createSheet("Invoices");
+            Row header = sheet.createRow(0);
+            header.createCell(0).setCellValue("Invoice No");
+            header.createCell(1).setCellValue("Customer");
+            header.createCell(2).setCellValue("Date");
+            header.createCell(3).setCellValue("Amount");
+            header.createCell(4).setCellValue("Status");
+
+            int rowIdx = 1;
+            for (Invoice inv : invoices) {
+                Row row = sheet.createRow(rowIdx++);
+                row.createCell(0).setCellValue(inv.getInvoiceNumber());
+                row.createCell(1).setCellValue(inv.getCustomer().getName());
+                row.createCell(2).setCellValue(inv.getDate().toString());
+                row.createCell(3).setCellValue(inv.getAmount());
+                row.createCell(4).setCellValue(inv.getStatus());
+            }
+            workbook.write(out);
+            return out.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException("Excel oluşturulamadı", e);
+        }
     }
 
 }

--- a/backend/src/main/java/com/finolo/service/mail/MailService.java
+++ b/backend/src/main/java/com/finolo/service/mail/MailService.java
@@ -1,0 +1,21 @@
+package com.finolo.service.mail;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MailService {
+
+    private final JavaMailSender mailSender;
+
+    public void sendWelcomeMail(String to) {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setTo(to);
+        message.setSubject("Finolo'ya Hoş Geldiniz!");
+        message.setText("Finolo'ya kayıt olduğunuz için teşekkür ederiz.");
+        mailSender.send(message);
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -8,3 +8,11 @@ spring.web.resources.add-mappings=false
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 spring.jpa.hibernate.ddl-auto=update
 spring.h2.console.enabled=true
+
+# SMTP configuration
+spring.mail.host=smtp.example.com
+spring.mail.port=587
+spring.mail.username=no-reply@example.com
+spring.mail.password=change-me
+spring.mail.properties.mail.smtp.auth=true
+spring.mail.properties.mail.smtp.starttls.enable=true

--- a/backend/src/test/java/com/finolo/controller/auth/AuthControllerTest.java
+++ b/backend/src/test/java/com/finolo/controller/auth/AuthControllerTest.java
@@ -61,6 +61,23 @@ class AuthControllerTest {
     }
 
     @Test
+    void shouldReturnError_WhenRegistrationFails() throws Exception {
+        RegisterRequest request = new RegisterRequest();
+        request.setEmail("exists@finolo.com");
+        request.setPassword("123456");
+        request.setBusinessName("Finolo");
+
+        when(authService.register(any())).thenThrow(new RuntimeException("Bu e-posta zaten kayıtlı."));
+
+        mockMvc.perform(post("/api/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("Bu e-posta zaten kayıtlı."));
+    }
+
+    @Test
     void shouldLoginSuccessfully() throws Exception {
         LoginRequest request = new LoginRequest();
         request.setEmail("login@finolo.com");

--- a/backend/src/test/java/com/finolo/controller/invoice/InvoiceControllerTest.java
+++ b/backend/src/test/java/com/finolo/controller/invoice/InvoiceControllerTest.java
@@ -89,8 +89,8 @@ class InvoiceControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(invoiceRequest)))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.invoiceNumber").value("INV-TEST-123456"))
-                .andExpect(jsonPath("$.amount").value(2500.0));
+                .andExpect(jsonPath("$.data.invoiceNumber").value("INV-TEST-123456"))
+                .andExpect(jsonPath("$.data.amount").value(2500.0));
     }
 
     @Test
@@ -100,8 +100,8 @@ class InvoiceControllerTest {
 
         mockMvc.perform(get("/api/invoices"))
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$[0].invoiceNumber").value("INV-TEST-123456"))
-                .andExpect(jsonPath("$[0].amount").value(2500.0))
-                .andExpect(jsonPath("$[0].status").value("DRAFT"));
+                .andExpect(jsonPath("$.data[0].invoiceNumber").value("INV-TEST-123456"))
+                .andExpect(jsonPath("$.data[0].amount").value(2500.0))
+                .andExpect(jsonPath("$.data[0].status").value("DRAFT"));
     }
 }

--- a/backend/src/test/java/com/finolo/service/auth/AuthServiceTest.java
+++ b/backend/src/test/java/com/finolo/service/auth/AuthServiceTest.java
@@ -3,6 +3,8 @@ package com.finolo.service.auth;
 import com.finolo.dto.auth.RegisterRequest;
 import com.finolo.model.User;
 import com.finolo.repository.UserRepository;
+import com.finolo.service.mail.MailService;
+import com.finolo.security.JwtService;
 import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -25,6 +27,12 @@ class AuthServiceTest {
     @Mock
     private PasswordEncoder passwordEncoder;
 
+    @Mock
+    private MailService mailService;
+
+    @Mock
+    private JwtService jwtService;
+
     @InjectMocks
     private AuthService authService;
 
@@ -44,12 +52,13 @@ class AuthServiceTest {
 
         when(userRepository.existsByEmail("test@example.com")).thenReturn(false);
         when(passwordEncoder.encode("password123")).thenReturn("hashed-pass");
-
+        when(jwtService.generateToken(anyString())).thenReturn("token");
         var response = authService.register(request);
 
         assertThat(response.getEmail()).isEqualTo("test@example.com");
         assertThat(response.getRole()).isEqualTo("USER");
         verify(userRepository, times(1)).save(any(User.class));
+        verify(mailService, times(1)).sendWelcomeMail("test@example.com");
     }
 
     @Test
@@ -66,5 +75,7 @@ class AuthServiceTest {
         assertThat(exception.getMessage()).isEqualTo("Bu e-posta zaten kayıtlı.");
 
         verify(userRepository, never()).save(any());
+        verify(mailService, never()).sendWelcomeMail(any());
+        verify(jwtService, never()).generateToken(any());
     }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,8 @@
         "react-dom": "^19.0.0",
         "react-icons": "^5.5.0",
         "react-router-dom": "^6.30.0",
-        "recharts": "^2.15.3"
+        "recharts": "^2.15.3",
+        "yup": "^1.6.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.22.0",
@@ -4772,6 +4773,12 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/property-expr": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/property-expr/-/property-expr-2.0.6.tgz",
+      "integrity": "sha512-SVtmxhRE/CGkn3eZY1T6pC8Nln6Fr/lu1mKSgRud0eC73whjGfoAogbn78LkD8aFL0zz3bAFerKSnOl7NlErBA==",
+      "license": "MIT"
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -5631,6 +5638,12 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tiny-case": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tiny-case/-/tiny-case-1.0.3.tgz",
+      "integrity": "sha512-Eet/eeMhkO6TX8mnUteS9zgPbUMQa4I6Kkp5ORiBD5476/m+PIRiumP5tmh5ioJpH7k51Kehawy2UDfsnxxY8Q==",
+      "license": "MIT"
+    },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
@@ -5676,6 +5689,12 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/toposort": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/toposort/-/toposort-2.0.2.tgz",
+      "integrity": "sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==",
+      "license": "MIT"
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -5694,6 +5713,18 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "2.19.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
+      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {
@@ -6034,6 +6065,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yup": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/yup/-/yup-1.6.1.tgz",
+      "integrity": "sha512-JED8pB50qbA4FOkDol0bYF/p60qSEDQqBD0/qeIrUCG1KbPBIQ776fCUNb9ldbPcSTxA69g/47XTo4TqWiuXOA==",
+      "license": "MIT",
+      "dependencies": {
+        "property-expr": "^2.0.5",
+        "tiny-case": "^1.0.3",
+        "toposort": "^2.0.2",
+        "type-fest": "^2.19.0"
       }
     },
     "node_modules/zod": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,8 @@
     "react-dom": "^19.0.0",
     "react-icons": "^5.5.0",
     "react-router-dom": "^6.30.0",
-    "recharts": "^2.15.3"
+    "recharts": "^2.15.3",
+    "yup": "^1.6.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.22.0",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,12 +3,14 @@ import Login from "./pages/Login";
 import Register from "./pages/Register";
 import Dashboard from "./pages/Dashboard";
 import Customers from "./pages/Customers";
+import CustomerForm from "./pages/CustomerForm.jsx";
 import Profile from "./pages/Profile";
 import PrivateRoute from "./routes/PrivateRoute";
 import Layout from "./components/Layout.jsx";
 import Invoices from "./pages/Invoices.jsx";
 import InvoiceForm from "./pages/InvoiceForm.jsx";
 import InvoiceDetail from "./pages/InvoiceDetail";
+import AdminPanel from "./pages/AdminPanel.jsx";
 
 function App() {
     return (
@@ -22,11 +24,12 @@ function App() {
                 <Route element={<PrivateRoute><Layout /></PrivateRoute>}>
                     <Route path="/dashboard" element={<Dashboard />} />
                     <Route path="/customers" element={<Customers />} />
-                    <Route path="/customers/new" element={<Customers />} />
+                    <Route path="/customers/new" element={<CustomerForm />} />
                     <Route path="/profile" element={<Profile />} />
                     <Route path="/invoices" element={<Invoices />} />
                     <Route path="/invoices/:id" element={<InvoiceDetail />} />
                     <Route path="/invoice/new" element={<InvoiceForm />} />
+                    <Route path="/admin" element={<AdminPanel />} />
                 </Route>
             </Routes>
         </Router>

--- a/frontend/src/components/Layout.jsx
+++ b/frontend/src/components/Layout.jsx
@@ -1,9 +1,25 @@
 import Navbar from "./Navbar";
 import {Outlet} from "react-router-dom";
+import {useEffect, useState} from "react";
+import TutorialOverlay from "./TutorialOverlay";
 
 function Layout() {
+    const [showTutorial, setShowTutorial] = useState(false);
+
+    useEffect(() => {
+        if (!localStorage.getItem("tutorialShown")) {
+            setShowTutorial(true);
+        }
+    }, []);
+
+    const closeTutorial = () => {
+        localStorage.setItem("tutorialShown", "true");
+        setShowTutorial(false);
+    };
+
     return (
-        <div className="flex flex-col min-h-screen bg-gray-100">
+        <div className="flex flex-col min-h-screen bg-gray-100 dark:bg-gray-900 dark:text-gray-100">
+            {showTutorial && <TutorialOverlay onClose={closeTutorial} />}
             <Navbar />
             <main className="flex-1 px-4 py-6 max-w-7xl mx-auto w-full">
                 <Outlet />

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,11 +1,14 @@
 import {NavLink, useNavigate} from "react-router-dom";
 import {useAuth} from "../context/AuthContext";
 import {useEffect, useState} from "react";
+import {useTheme} from "../context/ThemeContext.jsx";
+import {Sun, Moon} from "lucide-react";
 
 function Navbar() {
     const { user, logout } = useAuth();
     const navigate = useNavigate();
     const [menuOpen, setMenuOpen] = useState(false);
+    const { theme, toggleTheme } = useTheme();
 
     useEffect(() => {
         setMenuOpen(false); // rota değişince menü kapansın
@@ -13,11 +16,11 @@ function Navbar() {
 
     const linkClasses = ({ isActive }) =>
         isActive
-            ? "text-indigo-600 font-semibold"
-            : "text-gray-700 hover:text-indigo-600";
+            ? "text-indigo-600 dark:text-indigo-400 font-semibold"
+            : "text-gray-700 dark:text-gray-200 hover:text-indigo-600";
 
     return (
-        <nav className="bg-white border-b shadow-sm p-4 flex items-center justify-between relative z-50">
+        <nav className="bg-white dark:bg-gray-800 border-b dark:border-gray-700 shadow-sm p-4 flex items-center justify-between relative z-50">
             <div className="text-xl font-bold text-indigo-600 cursor-pointer" onClick={() => navigate("/dashboard")}>
                 Finolo
             </div>
@@ -25,12 +28,23 @@ function Navbar() {
             {/* Masaüstü Menü */}
             <div className="hidden md:flex gap-6 items-center">
                 <NavLink to="/dashboard" className={linkClasses}>Dashboard</NavLink>
-                <NavLink to="/customers" className={linkClasses}>Müşteriler</NavLink>
+                {user?.role === "USER" && (
+                    <>
+                        <NavLink to="/customers" className={linkClasses}>Müşteriler</NavLink>
+                        <NavLink to="/invoices" className={linkClasses}>Faturalar</NavLink>
+                    </>
+                )}
+                {user?.role === "ADMIN" && (
+                    <NavLink to="/admin" className={linkClasses}>Admin</NavLink>
+                )}
                 <NavLink to="/profile" className={linkClasses}>Profil</NavLink>
             </div>
 
             <div className="hidden md:flex items-center gap-4">
-                <span className="text-sm text-gray-600">{user?.email}</span>
+                <button onClick={toggleTheme} className="text-xl">
+                    {theme === "dark" ? <Sun /> : <Moon />}
+                </button>
+                <span className="text-sm text-gray-600 dark:text-gray-300">{user?.email}</span>
                 <button
                     onClick={() => {
                         logout();
@@ -44,7 +58,7 @@ function Navbar() {
 
             {/* Hamburger */}
             <div className="md:hidden">
-                <button onClick={() => setMenuOpen(!menuOpen)} className="text-indigo-600 text-2xl">
+                <button onClick={() => setMenuOpen(!menuOpen)} className="text-indigo-600 dark:text-indigo-400 text-2xl">
                     ☰
                 </button>
             </div>
@@ -52,7 +66,7 @@ function Navbar() {
             {/* Mobil Menü */}
             <div
                 className={`
-          fixed top-0 left-0 w-full h-screen bg-white/90 backdrop-blur-md transition-transform duration-300 ease-in-out
+          fixed top-0 left-0 w-full h-screen bg-white/90 dark:bg-gray-900/90 backdrop-blur-md transition-transform duration-300 ease-in-out
           flex flex-col z-40 px-6 py-4
           ${menuOpen ? "translate-x-0" : "-translate-x-full"}
         `}
@@ -61,20 +75,31 @@ function Navbar() {
           <h2 className="text-xl font-bold text-indigo-600">Finolo</h2>
           <button
             onClick={() => setMenuOpen(false)}
-            className="text-2xl text-gray-700 hover:text-indigo-600"
+            className="text-2xl text-gray-700 dark:text-gray-200 hover:text-indigo-600"
           >
             ✕
           </button>
         </div>
 
-        <nav className="flex flex-col gap-4 text-lg text-gray-700">
+        <nav className="flex flex-col gap-4 text-lg text-gray-700 dark:text-gray-200">
           <NavLink to="/dashboard" className={linkClasses}>Dashboard</NavLink>
-          <NavLink to="/customers" className={linkClasses}>Müşteriler</NavLink>
-            <NavLink to="/invoices" className={linkClasses}>Faturalar</NavLink>
-            <NavLink to="/profile" className={linkClasses}>Profil</NavLink>
+          {user?.role === "USER" && (
+            <>
+              <NavLink to="/customers" className={linkClasses}>Müşteriler</NavLink>
+              <NavLink to="/invoices" className={linkClasses}>Faturalar</NavLink>
+            </>
+          )}
+          {user?.role === "ADMIN" && (
+            <NavLink to="/admin" className={linkClasses}>Admin</NavLink>
+          )}
+          <NavLink to="/profile" className={linkClasses}>Profil</NavLink>
         </nav>
 
-        <div className="mt-auto pt-6 border-t text-sm text-gray-600">
+        <div className="mt-auto pt-6 border-t text-sm text-gray-600 dark:text-gray-300">
+          <button onClick={toggleTheme} className="mb-4 flex items-center gap-2">
+            {theme === "dark" ? <Sun size={18} /> : <Moon size={18} />}
+            <span>Temayı Değiştir</span>
+          </button>
           <p className="mb-2">{user?.email}</p>
           <button
             onClick={() => {

--- a/frontend/src/components/TutorialOverlay.jsx
+++ b/frontend/src/components/TutorialOverlay.jsx
@@ -1,0 +1,35 @@
+import {useState} from "react";
+
+function TutorialOverlay({ onClose }) {
+    const steps = [
+        { title: "Hoş Geldiniz", text: "Dashboard'da özet finans verilerini inceleyebilirsiniz." },
+        { title: "Müşteriler", text: "Müşteri kayıtlarınızı ve bilgilerini yönetin." },
+        { title: "Faturalar", text: "Yeni faturalar oluşturup geçmiş işlemleri takip edin." }
+    ];
+    const [index, setIndex] = useState(0);
+
+    const next = () => {
+        if (index < steps.length - 1) {
+            setIndex(index + 1);
+        } else {
+            onClose();
+        }
+    };
+
+    return (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">
+            <div className="bg-white p-6 rounded shadow max-w-md w-full text-center">
+                <h2 className="text-xl font-bold mb-2">{steps[index].title}</h2>
+                <p className="mb-4">{steps[index].text}</p>
+                <button
+                    onClick={next}
+                    className="bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700"
+                >
+                    {index < steps.length - 1 ? "Devam" : "Kapat"}
+                </button>
+            </div>
+        </div>
+    );
+}
+
+export default TutorialOverlay;

--- a/frontend/src/context/ThemeContext.jsx
+++ b/frontend/src/context/ThemeContext.jsx
@@ -1,0 +1,32 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+const ThemeContext = createContext();
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState(() =>
+    localStorage.getItem("theme") || "light"
+  );
+
+  useEffect(() => {
+    localStorage.setItem("theme", theme);
+    if (theme === "dark") {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme((prev) => (prev === "light" ? "dark" : "light"));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -3,9 +3,12 @@ import ReactDOM from "react-dom/client";
 import App from "./App.jsx";
 import "./index.css";
 import {AuthProvider} from "./context/AuthContext.jsx";
+import {ThemeProvider} from "./context/ThemeContext.jsx";
 
 ReactDOM.createRoot(document.getElementById("root")).render(
-        <AuthProvider>
-            <App />
-        </AuthProvider>
+  <ThemeProvider>
+    <AuthProvider>
+      <App />
+    </AuthProvider>
+  </ThemeProvider>
 );

--- a/frontend/src/pages/AdminPanel.jsx
+++ b/frontend/src/pages/AdminPanel.jsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+function AdminPanel() {
+    return (
+        <div className="p-4">
+            <h2 className="text-2xl font-bold text-indigo-600">Admin Panel</h2>
+            <p>Yalnızca yöneticiler için erişilebilir.</p>
+        </div>
+    );
+}
+
+export default AdminPanel;

--- a/frontend/src/pages/CustomerForm.jsx
+++ b/frontend/src/pages/CustomerForm.jsx
@@ -1,10 +1,21 @@
 import {useState} from "react";
+import * as Yup from "yup";
 import {useNavigate} from "react-router-dom";
 import {createCustomer} from "../services/customerService.js";
 
 function CustomerForm() {
   const [form, setForm] = useState({ name: "", email: "", phone: "", address: "" });
+  const [errors, setErrors] = useState({});
   const navigate = useNavigate();
+
+  const schema = Yup.object().shape({
+    name: Yup.string().required("İsim gerekli"),
+    email: Yup.string().email("Geçerli bir email girin").required("Email gerekli"),
+    phone: Yup.string()
+      .matches(/^\+?\d{10,15}$/, "Geçerli bir telefon numarası girin")
+      .required("Telefon gerekli"),
+    address: Yup.string().required("Adres gerekli")
+  });
 
   const handleChange = (e) => {
     setForm({ ...form, [e.target.name]: e.target.value });
@@ -13,21 +24,74 @@ function CustomerForm() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     try {
+      await schema.validate(form, { abortEarly: false });
       await createCustomer(form);
       navigate("/customers");
     } catch (error) {
-      console.error("Kayıt hatası:", error);
+      if (error instanceof Yup.ValidationError) {
+        const validationErrors = {};
+        error.inner.forEach((err) => {
+          if (err.path) validationErrors[err.path] = err.message;
+        });
+        setErrors(validationErrors);
+      } else {
+        console.error("Kayıt hatası:", error);
+      }
     }
   };
 
   return (
-    <div className="p-4 max-w-xl mx-auto">
+    <div className="p-4 max-w-xl mx-auto bg-white dark:bg-gray-800 rounded shadow">
       <h2 className="text-2xl font-bold mb-4">Yeni Müşteri</h2>
       <form onSubmit={handleSubmit} className="space-y-4">
-        <input type="text" name="name" placeholder="Ad Soyad" onChange={handleChange} className="w-full p-2 border rounded" />
-        <input type="email" name="email" placeholder="Email" onChange={handleChange} className="w-full p-2 border rounded" />
-        <input type="text" name="phone" placeholder="Telefon" onChange={handleChange} className="w-full p-2 border rounded" />
-        <input type="text" name="address" placeholder="Adres" onChange={handleChange} className="w-full p-2 border rounded" />
+        <div>
+          <input
+            type="text"
+            name="name"
+            placeholder="Ad Soyad"
+            onChange={handleChange}
+            className="w-full p-2 border rounded"
+            required
+          />
+          {errors.name && <p className="text-red-500 text-sm mt-1">{errors.name}</p>}
+        </div>
+
+        <div>
+          <input
+            type="email"
+            name="email"
+            placeholder="Email"
+            onChange={handleChange}
+            className="w-full p-2 border rounded"
+            required
+          />
+          {errors.email && <p className="text-red-500 text-sm mt-1">{errors.email}</p>}
+        </div>
+
+        <div>
+          <input
+            type="text"
+            name="phone"
+            placeholder="Telefon"
+            onChange={handleChange}
+            className="w-full p-2 border rounded"
+            required
+          />
+          {errors.phone && <p className="text-red-500 text-sm mt-1">{errors.phone}</p>}
+        </div>
+
+        <div>
+          <input
+            type="text"
+            name="address"
+            placeholder="Adres"
+            onChange={handleChange}
+            className="w-full p-2 border rounded"
+            required
+          />
+          {errors.address && <p className="text-red-500 text-sm mt-1">{errors.address}</p>}
+        </div>
+
         <button type="submit" className="w-full bg-indigo-600 text-white p-2 rounded">Kaydet</button>
       </form>
     </div>

--- a/frontend/src/pages/Customers.jsx
+++ b/frontend/src/pages/Customers.jsx
@@ -23,7 +23,7 @@ function Customers() {
       <h2 className="text-2xl font-bold mb-4">Müşteriler</h2>
       <div className="grid grid-cols-1 gap-4">
         {customers.map((c) => (
-          <div key={c.id} className="p-4 bg-white rounded shadow">
+          <div key={c.id} className="p-4 bg-white dark:bg-gray-800 rounded shadow">
             <h3 className="text-lg font-semibold">{c.name}</h3>
             <p>{c.email}</p>
             <p>{c.phone}</p>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -33,6 +33,7 @@ function Dashboard() {
                 const fetchPayments = await getPaymentStats();
                 if (fetchPayments.success) setPaymentStats(fetchPayments.data);
             } catch (err) {
+                console.error(err);
                 setError("Dashboard verileri alınamadı.");
             }
         };
@@ -55,7 +56,7 @@ function Dashboard() {
             )}
 
             {/* Son 5 Fatura */}
-            <div className="bg-white p-4 rounded shadow">
+            <div className="bg-white dark:bg-gray-800 p-4 rounded shadow">
                 <h2 className="text-lg font-semibold text-indigo-600 mb-4">Son Faturalar</h2>
                 {recentInvoices.length > 0 ? (
                     <table className="w-full text-sm">
@@ -70,7 +71,7 @@ function Dashboard() {
                         </thead>
                         <tbody>
                         {recentInvoices.map((inv) => (
-                            <tr key={inv.id} className="border-b hover:bg-gray-50">
+                            <tr key={inv.id} className="border-b hover:bg-gray-50 dark:hover:bg-gray-700">
                                 <td>{inv.invoiceNumber}</td>
                                 <td>{inv.customerName}</td>
                                 <td>{inv.date}</td>
@@ -87,12 +88,12 @@ function Dashboard() {
 
             {/* Grafik ve Tahsilat */}
             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                <div className="bg-white p-4 rounded shadow md:col-span-2">
+                <div className="bg-white dark:bg-gray-800 p-4 rounded shadow md:col-span-2">
                     <h2 className="text-lg font-semibold text-indigo-600 mb-4">Aylık Fatura Gelirleri</h2>
                     <MonthlyBarChart data={monthlyStats} />
                 </div>
 
-                <div className="bg-white p-4 rounded shadow">
+                <div className="bg-white dark:bg-gray-800 p-4 rounded shadow">
                     <h2 className="text-lg font-semibold text-indigo-600 mb-4">Tahsilat Durumu</h2>
                     <PaymentDonutChart data={paymentStats} />
                 </div>

--- a/frontend/src/pages/InvoiceDetail.jsx
+++ b/frontend/src/pages/InvoiceDetail.jsx
@@ -29,6 +29,7 @@ function InvoiceDetail() {
                     setCustomers(customerData.data);
                 }
             } catch (err) {
+                console.error(err);
                 setError("Fatura detayları alınamadı.");
             }
         };
@@ -56,7 +57,7 @@ function InvoiceDetail() {
     if (!invoice) return <p className="text-center text-gray-500">Yükleniyor...</p>;
 
     return (
-        <div className="max-w-2xl mx-auto bg-white p-6 rounded shadow mt-6">
+        <div className="max-w-2xl mx-auto bg-white dark:bg-gray-800 p-6 rounded shadow mt-6">
             {/* Geri Butonu */}
             <button
                 onClick={() => navigate("/invoices")}

--- a/frontend/src/pages/InvoiceForm.jsx
+++ b/frontend/src/pages/InvoiceForm.jsx
@@ -1,4 +1,5 @@
 import {useEffect, useState} from "react";
+import * as Yup from "yup";
 import {useNavigate} from "react-router-dom";
 import {getCustomers} from "../services/customerService";
 import {createInvoice} from "../services/invoiceService";
@@ -9,6 +10,7 @@ function InvoiceForm() {
     const [customers, setCustomers] = useState([]);
     const [error, setError] = useState("");
     const [showModal, setShowModal] = useState(false);
+    const [formErrors, setFormErrors] = useState({});
 
     const [formData, setFormData] = useState({
         amount: "",
@@ -20,6 +22,14 @@ function InvoiceForm() {
         taxRate: 0,
         note: "",
         paymentMethod: ""
+    });
+
+    const schema = Yup.object().shape({
+        amount: Yup.number().typeError("Tutar sayı olmalı").positive("Tutar pozitif olmalı").required("Tutar gerekli"),
+        date: Yup.date().required("Fatura tarihi gerekli"),
+        dueDate: Yup.date().nullable(),
+        description: Yup.string().required("Açıklama gerekli"),
+        customerId: Yup.string().required("Müşteri seçimi gerekli")
     });
 
     useEffect(() => {
@@ -49,22 +59,26 @@ function InvoiceForm() {
 
     const handleSubmit = async (e) => {
         e.preventDefault();
-        if (!formData.customerId) {
-            alert("Lütfen bir müşteri seçin.");
-            return;
-        }
-
         try {
+            await schema.validate(formData, { abortEarly: false });
             await createInvoice(formData);
             navigate("/invoices");
         } catch (err) {
-            console.error(err);
-            setError("Fatura oluşturulamadı.");
+            if (err instanceof Yup.ValidationError) {
+                const validationErrors = {};
+                err.inner.forEach((e) => {
+                    if (e.path) validationErrors[e.path] = e.message;
+                });
+                setFormErrors(validationErrors);
+            } else {
+                console.error(err);
+                setError("Fatura oluşturulamadı.");
+            }
         }
     };
 
     return (
-        <div className="max-w-2xl mx-auto mt-10 p-6 bg-white rounded shadow">
+        <div className="max-w-2xl mx-auto mt-10 p-6 bg-white dark:bg-gray-800 rounded shadow">
             <h2 className="text-2xl font-bold mb-6">Fatura Oluştur</h2>
             <form onSubmit={handleSubmit} className="space-y-5">
 
@@ -77,7 +91,11 @@ function InvoiceForm() {
                         onChange={handleChange}
                         className="w-full p-2 border rounded"
                         required
+                        min="0"
                     />
+                    {formErrors.amount && (
+                        <p className="text-red-500 text-sm mt-1">{formErrors.amount}</p>
+                    )}
                 </div>
 
                 <div>
@@ -90,6 +108,9 @@ function InvoiceForm() {
                         className="w-full p-2 border rounded"
                         required
                     />
+                    {formErrors.date && (
+                        <p className="text-red-500 text-sm mt-1">{formErrors.date}</p>
+                    )}
                 </div>
 
                 <div>
@@ -101,6 +122,9 @@ function InvoiceForm() {
                         onChange={handleChange}
                         className="w-full p-2 border rounded"
                     />
+                    {formErrors.dueDate && (
+                        <p className="text-red-500 text-sm mt-1">{formErrors.dueDate}</p>
+                    )}
                 </div>
 
                 <div>
@@ -113,6 +137,9 @@ function InvoiceForm() {
                         className="w-full p-2 border rounded"
                         required
                     />
+                    {formErrors.description && (
+                        <p className="text-red-500 text-sm mt-1">{formErrors.description}</p>
+                    )}
                 </div>
 
                 <div>
@@ -131,6 +158,9 @@ function InvoiceForm() {
                             </option>
                         ))}
                     </select>
+                    {formErrors.customerId && (
+                        <p className="text-red-500 text-sm mt-1">{formErrors.customerId}</p>
+                    )}
                 </div>
 
                 <div>

--- a/frontend/src/pages/Invoices.jsx
+++ b/frontend/src/pages/Invoices.jsx
@@ -35,8 +35,9 @@ function Invoices() {
         }
     };
 
-    const downloadFile = (data, filename) => {
-        const url = window.URL.createObjectURL(new Blob([data]));
+    const downloadFile = (data, filename, type) => {
+        const blob = data instanceof Blob ? data : new Blob([data], { type });
+        const url = window.URL.createObjectURL(blob);
         const link = document.createElement("a");
         link.href = url;
         link.setAttribute("download", filename);
@@ -48,7 +49,7 @@ function Invoices() {
     const handleExportPdf = async () => {
         try {
             const res = await exportInvoicesPdf();
-            downloadFile(res.data, "invoices.pdf");
+            downloadFile(res.data, "invoices.pdf", "application/pdf");
         } catch (err) {
             console.error("PDF indirilemedi", err);
         }
@@ -57,7 +58,7 @@ function Invoices() {
     const handleExportExcel = async () => {
         try {
             const res = await exportInvoicesExcel();
-            downloadFile(res.data, "invoices.xlsx");
+            downloadFile(res.data, "invoices.xlsx", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
         } catch (err) {
             console.error("Excel indirilemedi", err);
         }

--- a/frontend/src/pages/Invoices.jsx
+++ b/frontend/src/pages/Invoices.jsx
@@ -1,5 +1,5 @@
 import {useEffect, useState} from "react";
-import {deleteInvoice, getInvoices} from "../services/invoiceService";
+import {deleteInvoice, getInvoices, exportInvoicesPdf, exportInvoicesExcel} from "../services/invoiceService";
 import {Link} from "react-router-dom";
 import {formatDate} from "../utils/dateUtils";
 import {Plus} from "lucide-react";
@@ -35,12 +35,54 @@ function Invoices() {
         }
     };
 
+    const downloadFile = (data, filename) => {
+        const url = window.URL.createObjectURL(new Blob([data]));
+        const link = document.createElement("a");
+        link.href = url;
+        link.setAttribute("download", filename);
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+    };
+
+    const handleExportPdf = async () => {
+        try {
+            const res = await exportInvoicesPdf();
+            downloadFile(res.data, "invoices.pdf");
+        } catch (err) {
+            console.error("PDF indirilemedi", err);
+        }
+    };
+
+    const handleExportExcel = async () => {
+        try {
+            const res = await exportInvoicesExcel();
+            downloadFile(res.data, "invoices.xlsx");
+        } catch (err) {
+            console.error("Excel indirilemedi", err);
+        }
+    };
+
     return (
         <div className="overflow-x-auto w-full">
             <h2 className="text-2xl font-bold text-indigo-600 mb-4">Faturalar</h2>
+            <div className="flex justify-end space-x-2 mb-4">
+                <button
+                    onClick={handleExportPdf}
+                    className="px-3 py-2 text-sm rounded bg-indigo-600 text-white hover:bg-indigo-700"
+                >
+                    PDF İndir
+                </button>
+                <button
+                    onClick={handleExportExcel}
+                    className="px-3 py-2 text-sm rounded bg-green-600 text-white hover:bg-green-700"
+                >
+                    Excel İndir
+                </button>
+            </div>
 
-            <table className="min-w-full w-full text-sm text-left text-gray-700 bg-white shadow rounded">
-                <thead className="bg-gray-100 text-sm text-gray-700">
+            <table className="min-w-full w-full text-sm text-left text-gray-700 dark:text-gray-200 bg-white dark:bg-gray-800 shadow rounded">
+                <thead className="bg-gray-100 dark:bg-gray-700 text-sm text-gray-700 dark:text-gray-200">
                 <tr>
                     <th className="px-4 py-2 text-left">Fatura No</th>
                     <th className="px-4 py-2 text-left">Müşteri</th>

--- a/frontend/src/pages/Login.jsx
+++ b/frontend/src/pages/Login.jsx
@@ -24,15 +24,16 @@ function Login() {
             login(data, data.token);
             navigate("/dashboard");
         } catch (err) {
+            console.error(err);
             setError("Giriş başarısız. Lütfen bilgilerinizi kontrol edin.");
         }
     };
 
     return (
-        <div className="min-h-screen flex flex-col justify-center items-center bg-gray-100 px-4">
+        <div className="min-h-screen flex flex-col justify-center items-center bg-gray-100 dark:bg-gray-900 px-4">
             <img src={finoloLogo} alt="Finolo Logo" className="w-32 mb-6" />
 
-            <div className="w-full max-w-md bg-white p-6 rounded shadow">
+            <div className="w-full max-w-md bg-white dark:bg-gray-800 p-6 rounded shadow">
                 <h2 className="text-xl font-semibold text-center text-indigo-600 mb-4">Giriş Yap</h2>
 
                 <form onSubmit={handleSubmit} className="space-y-4">

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -23,7 +23,7 @@ function Profile() {
     if (loading) return <div className="p-4">Yükleniyor...</div>;
 
     return (
-        <div className="max-w-md mx-auto mt-10 p-6 bg-white rounded shadow">
+        <div className="max-w-md mx-auto mt-10 p-6 bg-white dark:bg-gray-800 rounded shadow">
             <h2 className="text-2xl font-bold mb-4 text-indigo-600">Profil Bilgileri</h2>
             <div className="space-y-2">
                 <p><strong>Firma Adı:</strong> {user.businessName}</p>

--- a/frontend/src/pages/Register.jsx
+++ b/frontend/src/pages/Register.jsx
@@ -29,15 +29,16 @@ function Register() {
             login(data, data.token); // otomatik giriş
             navigate("/dashboard");
         } catch (err) {
+            console.error(err);
             setError("Kayıt başarısız. Lütfen bilgilerinizi kontrol edin.");
         }
     };
 
     return (
-        <div className="min-h-screen flex flex-col justify-center items-center bg-gray-100 px-4">
+        <div className="min-h-screen flex flex-col justify-center items-center bg-gray-100 dark:bg-gray-900 px-4">
             <img src={finoloLogo} alt="Finolo Logo" className="w-32 mb-6" />
 
-            <div className="w-full max-w-md bg-white p-6 rounded shadow">
+            <div className="w-full max-w-md bg-white dark:bg-gray-800 p-6 rounded shadow">
                 <h2 className="text-xl font-semibold text-center text-indigo-600 mb-4">Kayıt Ol</h2>
 
                 <form onSubmit={handleSubmit} className="space-y-4">

--- a/frontend/src/services/invoiceService.js
+++ b/frontend/src/services/invoiceService.js
@@ -25,4 +25,12 @@ export const updateInvoice = async (id, data) => {
     return res.data;
 };
 
+export const exportInvoicesPdf = async () => {
+    return api.get('/invoices/export/pdf', { responseType: 'blob' });
+};
+
+export const exportInvoicesExcel = async () => {
+    return api.get('/invoices/export/excel', { responseType: 'blob' });
+};
+
 

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -4,6 +4,7 @@ export default {
     "./index.html",
     "./src/**/*.{js,jsx,ts,tsx}",
   ],
+  darkMode: "class",
   theme: {
     extend: {},
   },


### PR DESCRIPTION
## Summary
- allow CORS for the frontend origin
- add PDF and Excel export utilities in invoice service
- expose `/api/invoices/export/pdf` and `/api/invoices/export/excel` endpoints
- add download buttons in the invoice page
- merge latest master

## Testing
- `./mvnw test -DskipTests=false`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6846f0eb1c30832e8d152fe6c8870cf6